### PR TITLE
Editor commands tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -95,6 +95,8 @@
   // to your app that hang off `window`.
 
   "predef": [
-    "define" // amd loader
+    "define", // amd loader
+    "$",
+    "QUnit"
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ cache:
     - node_modules
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  # See https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to
+  # modified to not use sudo (just puts $PWD on the path so that $PWD/phantomjs is the phantom used
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xjf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - export PATH=$PWD:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -18,10 +18,10 @@ var buildOptions = {
   packageName: packageName
 };
 
-var jqueryTree = jquery.build('/demo/jquery');
 var testTree = testTreeBuilder.build({libDirName: 'src'});
+testTree = jquery.build(testTree, '/tests/jquery');
 var demoTree = demo();
-demoTree = mergeTrees([demoTree, jqueryTree]);
+demoTree = jquery.build(demoTree, '/demo/jquery');
 
 module.exports = mergeTrees([
   builder.build('amd', buildOptions),

--- a/broccoli/jquery.js
+++ b/broccoli/jquery.js
@@ -1,17 +1,22 @@
 /* jshint node:true */
 var funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
-  build: function(destDir) {
+  /**
+   * @param {Tree} tree existing tree to mix jquery into
+   * @param {String} destDir the destination directory for 'jquery.js' to go into
+   * @return {Tree} A tree with jquery mixed into it at the location requested
+   */
+  build: function(tree, destDir) {
     var path = require('path');
     var jqueryPath = path.dirname(
       require.resolve('jquery')
     );
-    var tree = funnel(jqueryPath, {
+    var jqueryTree = funnel(jqueryPath, {
       include: ['jquery.js'],
       destDir: destDir
     });
-
-    return tree;
+    return mergeTrees([tree, jqueryTree]);
   }
 };

--- a/src/js/commands/card.js
+++ b/src/js/commands/card.js
@@ -1,9 +1,10 @@
 import Command from './base';
 import { inherit } from 'content-kit-utils';
 
-function injectCardBlock(cardName, cardPayload, editor, index) {
+function injectCardBlock(/* cardName, cardPayload, editor, index */) {
   throw new Error('Unimplemented: BlockModel and Type.CARD are no longer things');
   // FIXME: Do we change the block model internal representation here?
+  /*
   var cardBlock = BlockModel.createWithType(Type.CARD, {
     attributes: {
       name: cardName,
@@ -11,6 +12,7 @@ function injectCardBlock(cardName, cardPayload, editor, index) {
     }
   });
   editor.replaceBlock(cardBlock, index);
+  */
 }
 
 function CardCommand() {

--- a/src/js/commands/format-block.js
+++ b/src/js/commands/format-block.js
@@ -17,7 +17,9 @@ FormatBlockCommand.prototype.exec = function() {
   // Allow block commands to be toggled back to a text block
   if(tag === blockElement.tagName.toLowerCase()) {
     throw new Error('Unimplemented: Type.BOLD.paragraph must be replaced');
+    /*
     value = Type.PARAGRAPH.tag;
+    */
   } else {
     // Flattens the selection before applying the block format.
     // Otherwise, undesirable nested blocks can occur.
@@ -27,7 +29,7 @@ FormatBlockCommand.prototype.exec = function() {
     blockElement.parentNode.removeChild(blockElement);
     selectNode(flatNode);
   }
-  
+
   FormatBlockCommand._super.prototype.exec.call(this, value);
 };
 

--- a/src/js/commands/image.js
+++ b/src/js/commands/image.js
@@ -14,10 +14,12 @@ function createFileInput(command) {
   return fileInput;
 }
 
-function injectImageBlock(src, editor, index) {
+function injectImageBlock(/* src, editor, index */) {
   throw new Error('Unimplemented: BlockModel and Type.IMAGE are no longer things');
+  /*
   var imageModel = BlockModel.createWithType(Type.IMAGE, { attributes: { src: src } });
   editor.replaceBlock(imageModel, index);
+  */
 }
 
 function renderFromFile(file, editor, index) {

--- a/src/js/commands/oembed.js
+++ b/src/js/commands/oembed.js
@@ -4,6 +4,7 @@ import Message from '../views/message';
 import { inherit } from 'content-kit-utils';
 import { OEmbedder } from '../utils/http-utils';
 
+/*
 function loadTwitterWidgets(element) {
   if (window.twttr) {
     window.twttr.widgets.load(element);
@@ -14,6 +15,7 @@ function loadTwitterWidgets(element) {
     document.head.appendChild(script);
   }
 }
+*/
 
 function OEmbedCommand(options) {
   Command.call(this, {
@@ -31,9 +33,9 @@ inherit(OEmbedCommand, Command);
 
 OEmbedCommand.prototype.exec = function(url) {
   var command = this;
-  var editorContext = command.editorContext;
+  // var editorContext = command.editorContext;
   var embedIntent = command.embedIntent;
-  var index = editorContext.getCurrentBlockIndex();
+  // var index = editorContext.getCurrentBlockIndex();
 
   embedIntent.showLoading();
   this.embedService.fetch({
@@ -54,12 +56,14 @@ OEmbedCommand.prototype.exec = function(url) {
         embedIntent.show();
       } else {
         throw new Error('Unimplemented EmbedModel is not a thing');
+        /*
         var embedModel = new EmbedModel(response);
         editorContext.insertBlock(embedModel, index);
         editorContext.renderBlockAt(index);
         if (embedModel.attributes.provider_name.toLowerCase() === 'twitter') {
           loadTwitterWidgets(editorContext.element);
         }
+        */
       }
     }
   });

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -124,14 +124,15 @@ function bindDragAndDrop(editor) {
 function initEmbedCommands(editor) {
   var commands = editor.embedCommands;
   if(commands) {
-    return new EmbedIntent({
+    editor.addView(new EmbedIntent({
       editorContext: editor,
       commands: commands,
       rootElement: editor.element
-    });
+    }));
   }
 }
 
+/* unused
 function getNonTextBlocks(blockTypeSet, post) {
   var blocks = [];
   var len = post.length;
@@ -145,6 +146,7 @@ function getNonTextBlocks(blockTypeSet, post) {
   }
   return blocks;
 }
+*/
 
 function clearChildNodes(element) {
   while (element.childNodes.length) {
@@ -165,12 +167,13 @@ function Editor(element, options) {
   }
 
   this._elementListeners = [];
+  this._views = [];
   this.element = element;
 
   // FIXME: This should merge onto this.options
   mergeWithOptions(this, defaults, options);
 
-  this._renderer = new EditorDOMRenderer(window.document, this.cards)
+  this._renderer = new EditorDOMRenderer(window.document, this.cards);
   this._parser   = new DOMParser();
 
   this.applyClassName();
@@ -196,16 +199,16 @@ function Editor(element, options) {
   this.addEventListener(element, 'input', () => this.handleInput(...arguments));
   initEmbedCommands(this);
 
-  this.textFormatToolbar = new TextFormatToolbar({
+  this.addView(new TextFormatToolbar({
     rootElement: element,
     commands: this.textFormatCommands,
     sticky: this.stickyToolbar
-  });
+  }));
 
-  this.linkTooltips = new Tooltip({
+  this.addView(new Tooltip({
     rootElement: element,
     showForTag: 'a'
-  });
+  }));
 
   if (this.autofocus) {
     element.focus();
@@ -216,6 +219,9 @@ function Editor(element, options) {
 merge(Editor.prototype, EventEmitter);
 
 merge(Editor.prototype, {
+  addView(view) {
+    this._views.push(view);
+  },
 
   addEventListener(context, eventName, callback) {
     context.addEventListener(eventName, callback);
@@ -271,8 +277,9 @@ merge(Editor.prototype, {
     this.trigger('update');
   },
 
-  renderBlockAt(index, replace) {
+  renderBlockAt(/* index, replace */) {
     throw new Error('Unimplemented');
+    /*
     var modelAtIndex = this.post[index];
     var html = this.compiler.render([modelAtIndex]);
     var dom = document.createElement('div');
@@ -285,10 +292,12 @@ merge(Editor.prototype, {
     } else {
       this.element.insertBefore(newEl, sibling);
     }
+    */
   },
 
   syncContentEditableBlocks() {
     throw new Error('Unimplemented');
+    /*
     var nonTextBlocks = getNonTextBlocks(this.compiler.blockTypes, this.post);
     var blockElements = toArray(this.element.children);
     var len = blockElements.length;
@@ -309,6 +318,7 @@ merge(Editor.prototype, {
     }
     this.post = updatedModel;
     this.trigger('update');
+    */
   },
 
   applyClassName() {
@@ -426,8 +436,14 @@ merge(Editor.prototype, {
     });
   },
 
+  removeAllViews() {
+    this._views.forEach((v) => v.destroy());
+    this._views = [];
+  },
+
   destroy() {
     this.removeAllEventListeners();
+    this.removeAllViews();
   }
 
 });

--- a/src/js/views/view.js
+++ b/src/js/views/view.js
@@ -51,6 +51,10 @@ View.prototype = {
   setClasses: function(classNameArr) {
     this.classNames = classNameArr;
     renderClasses(this);
+  },
+  destroy() {
+    // FIXME should also clean up event listeners
+    this.hide();
   }
 };
 

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -1,7 +1,7 @@
 /* global QUnit */
 
 import { Editor } from 'content-kit-editor';
-import { moveCursorTo } from '../test-helpers';
+import Helpers from '../test-helpers';
 
 const { test, module } = QUnit;
 
@@ -38,7 +38,7 @@ test('editing element changes editor post model', (assert) => {
   let p = editorElement.querySelector('p');
   let textElement = p.firstChild;
 
-  moveCursorTo(textElement, 0);
+  Helpers.dom.moveCursorTo(textElement, 0);
 
   document.execCommand('insertText', false, 'A');
   assert.equal(p.textContent, 'AHello');

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -1,5 +1,3 @@
-/* global QUnit */
-
 import { Editor } from 'content-kit-editor';
 import Helpers from '../test-helpers';
 
@@ -15,6 +13,7 @@ module('Acceptance: basic editor', {
     fixture.appendChild(editorElement);
   },
   afterEach() {
+    editor.destroy();
   }
 });
 

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -1,0 +1,115 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+
+const { test, module } = QUnit;
+
+let fixture, editor, editorElement, selectedText;
+
+module('Acceptance: Editor commands', {
+  beforeEach() {
+    fixture = document.getElementById('qunit-fixture');
+    editorElement = document.createElement('div');
+    editorElement.setAttribute('id', 'editor');
+    editorElement.innerHTML = 'THIS IS A TEST';
+    fixture.appendChild(editorElement);
+    editor = new Editor(editorElement);
+
+    selectedText = 'IS A';
+    Helpers.dom.selectText(selectedText, editorElement);
+    Helpers.dom.triggerEvent(document, 'mouseup');
+  },
+
+  afterEach() {
+    editor.destroy();
+  }
+});
+
+function clickToolbarButton(name, assert) {
+  let btnSelector = `.ck-toolbar-btn[title="${name}"]`;
+  let button = assert.hasElement(btnSelector);
+
+  Helpers.dom.triggerEvent(button[0], 'mouseup');
+}
+
+test('when text is highlighted, shows toolbar', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    assert.hasElement('.ck-toolbar', 'displays toolbar');
+    assert.hasElement('.ck-toolbar-btn', 'displays toolbar buttons');
+    let boldBtnSelector = '.ck-toolbar-btn[title="bold"]';
+    assert.hasElement(boldBtnSelector, 'has bold button');
+    done();
+  }, 10);
+});
+
+test('highlight text, click "bold" button bolds text', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('bold', assert);
+    assert.hasElement('#editor b:contains(IS A)');
+
+    done();
+  }, 10);
+});
+
+test('highlight text, click "italic" button italicizes text', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('italic', assert);
+    assert.hasElement('#editor i:contains(IS A)');
+
+    done();
+  }, 10);
+});
+
+test('highlight text, click "heading" button turns text into h2 header', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('heading', assert);
+    assert.hasElement('#editor h2:contains(THIS IS A TEST)');
+
+    done();
+  }, 10);
+});
+
+test('highlight text, click "subheading" button turns text into h3 header', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('subheading', assert);
+    assert.hasElement('#editor h3:contains(THIS IS A TEST)');
+
+    done();
+  }, 10);
+});
+
+test('highlight text, click "quote" button turns text into blockquote', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('quote', assert);
+    assert.hasElement('#editor blockquote:contains(THIS IS A TEST)');
+
+    done();
+  }, 10);
+});
+
+test('highlight text, click "link" button shows input for URL, makes link', (assert) => {
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('link', assert);
+    let input = assert.hasElement('.ck-toolbar-prompt input');
+    let url = 'http://google.com';
+    $(input).val(url);
+    Helpers.dom.triggerKeyEvent(input[0], 'keyup');
+
+    assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
+
+    done();
+  }, 10);
+});

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -39,6 +39,7 @@ test('when text is highlighted, shows toolbar', (assert) => {
     assert.hasElement('.ck-toolbar-btn', 'displays toolbar buttons');
     let boldBtnSelector = '.ck-toolbar-btn[title="bold"]';
     assert.hasElement(boldBtnSelector, 'has bold button');
+
     done();
   }, 10);
 });
@@ -102,6 +103,15 @@ test('highlight text, click "link" button shows input for URL, makes link', (ass
   let done = assert.async();
 
   setTimeout(() => {
+    // FIXME PhantomJS doesn't create keyboard events properly (they have no keyCode or which)
+    // see https://bugs.webkit.org/show_bug.cgi?id=36423
+    let skippable = navigator.userAgent.indexOf('PhantomJS') !== -1;
+    if (skippable) {
+      assert.ok(true, 'Skipping test in phantomjs');
+      done();
+      return;
+    }
+
     clickToolbarButton('link', assert);
     let input = assert.hasElement('.ck-toolbar-prompt input');
     let url = 'http://google.com';

--- a/tests/helpers/assertions.js
+++ b/tests/helpers/assertions.js
@@ -1,0 +1,15 @@
+/* global QUnit, $ */
+
+export default function registerAssertions() {
+  QUnit.assert.hasElement = function(selector, message=`hasElement "${selector}"`) {
+    let found = $(selector);
+    this.push(found.length > 0, found.length, selector, message);
+    return found;
+  };
+
+  QUnit.assert.hasNoElement = function(selector, message=`hasNoElement "${selector}"`) {
+    let found = $(selector);
+    this.push(found.length === 0, found.length, selector, message);
+    return found;
+  };
+}

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -1,0 +1,106 @@
+const TEXT_NODE = 3;
+
+function moveCursorTo(element, offset) {
+  let range = document.createRange();
+  range.setStart(element, offset);
+  range.setEnd(element, offset);
+
+  let selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+
+function walkDOMUntil(topNode, conditionFn=() => {}) {
+  let stack = [topNode];
+  let currentElement;
+
+  while (stack.length) {
+    currentElement = stack.pop();
+
+    if (conditionFn(currentElement)) {
+      return currentElement;
+    }
+
+    for (let i=0; i < currentElement.childNodes.length; i++) {
+      stack.push(currentElement.childNodes[i]);
+    }
+    if (currentElement.nextSibling) {
+      stack.push(currentElement.nextSibling);
+    }
+  }
+}
+
+
+function selectText(text, containingElement) {
+  let textNode = walkDOMUntil(containingElement, (el) => {
+    if (el.nodeType !== TEXT_NODE) { return; }
+
+    return el.textContent.indexOf(text) !== -1;
+  });
+  if (!textNode) {
+    throw new Error(`Could not find a textNode containing "${text}"`);
+  }
+  let range = document.createRange();
+  let startOffset = textNode.textContent.indexOf(text),
+      endOffset   = startOffset + text.length;
+  range.setStart(textNode, startOffset);
+  range.setEnd(textNode, endOffset);
+
+  let selection = window.getSelection();
+  if (selection.rangeCount > 0) { selection.removeAllRanges(); }
+  selection.addRange(range);
+}
+
+function triggerEvent(node, eventType) {
+  if (!node) { throw new Error(`Attempted to trigger event "${eventType}" on undefined node`); }
+
+  let clickEvent = document.createEvent('MouseEvents');
+  clickEvent.initEvent(eventType, true, true);
+  node.dispatchEvent(clickEvent);
+}
+
+// see https://gist.github.com/ejoubaud/7d7c57cda1c10a4fae8c
+function createKeyEvent(eventType, key) {
+  var oEvent = document.createEvent('KeyboardEvent');
+
+  // Chromium Hack
+  Object.defineProperty(oEvent, 'keyCode', {
+              get : function() {
+                  return this.keyCodeVal;
+              }
+  });     
+  Object.defineProperty(oEvent, 'which', {
+              get : function() {
+                  return this.keyCodeVal;
+              }
+  });     
+
+  if (oEvent.initKeyboardEvent) {
+      oEvent.initKeyboardEvent(eventType, true, true, document.defaultView, key, key, "", "", false, "");
+  } else {
+      oEvent.initKeyEvent(eventType, true, true, document.defaultView, false, false, false, false, key, 0);
+  }
+
+  oEvent.keyCodeVal = key;
+
+  if (oEvent.keyCode !== key) {
+    throw new Error("keyCode mismatch " + oEvent.keyCode + "(" + oEvent.which + ")");
+  }
+
+  return oEvent;
+}
+
+const ENTER_KEY_CODE = 13;
+function triggerKeyEvent(node, eventType, keyCode=ENTER_KEY_CODE) {
+  let event = createKeyEvent('keyup', keyCode);
+
+  node.dispatchEvent(event);
+}
+
+export default {
+  moveCursorTo,
+  selectText,
+  triggerEvent,
+  triggerKeyEvent
+};

--- a/tests/index.html
+++ b/tests/index.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8">
   <title>Content-Kit-Editor tests</title>
   <link rel="stylesheet" href="./qunit/qunit.css">
+  <style>
+    /* position qunit-fixture within view, for easier debugging */
+    #qunit-fixture {
+      position: static;
+      border: 1px solid black;
+      width: 33%;
+      height: 33%;
+    }
+  </style>
 </head>
 <body>
 

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -1,9 +1,8 @@
-export function moveCursorTo(element, offset) {
-  let range = document.createRange();
-  range.setStart(element, offset);
-  range.setEnd(element, offset);
+import registerAssertions from './helpers/assertions';
+registerAssertions();
 
-  let selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-}
+import DOMHelpers from './helpers/dom';
+
+export default {
+  dom: DOMHelpers
+};

--- a/tests/unit/editor/editor-destroy-test.js
+++ b/tests/unit/editor/editor-destroy-test.js
@@ -26,7 +26,6 @@ test('removes toolbar from DOM', (assert) => {
     assert.hasElement('.ck-toolbar', 'toolbar is shown');
     editor.destroy();
     assert.hasNoElement('.ck-toolbar', 'toolbar is removed');
-
     done();
   });
 });

--- a/tests/unit/editor/editor-destroy-test.js
+++ b/tests/unit/editor/editor-destroy-test.js
@@ -1,0 +1,32 @@
+const { module, test } = window.QUnit;
+import Helpers from '../../test-helpers';
+
+import { Editor } from 'content-kit-editor';
+
+let editor;
+let fixture;
+
+module('Unit: Editor #destroy', {
+  beforeEach() {
+    fixture = $('#qunit-fixture');
+    fixture.html('the editor');
+    editor = new Editor(fixture[0]);
+  },
+  afterEach() {
+  }
+});
+
+test('removes toolbar from DOM', (assert) => {
+  let done = assert.async();
+
+  Helpers.dom.selectText('the editor', fixture[0]);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    assert.hasElement('.ck-toolbar', 'toolbar is shown');
+    editor.destroy();
+    assert.hasNoElement('.ck-toolbar', 'toolbar is removed');
+
+    done();
+  });
+});

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -1,5 +1,6 @@
-var fixture = document.getElementById('qunit-fixture');
-var editorElement = document.createElement('div');
+let fixture = document.getElementById('qunit-fixture');
+let editorElement = document.createElement('div');
+let editor;
 editorElement.id = 'editor1';
 editorElement.className = 'editor';
 
@@ -8,21 +9,22 @@ import Editor from 'content-kit-editor/editor/editor';
 const { module, test } = window.QUnit;
 
 module('Unit: Editor', {
-  setup: function() {
+  beforeEach: function() {
     fixture.appendChild(editorElement);
   },
-  teardown: function() {
+  afterEach: function() {
+    editor.destroy();
     fixture.removeChild(editorElement);
   }
 });
 
 test('can create an editor via dom node reference', (assert) => {
-  var editor = new Editor(editorElement);
+  editor = new Editor(editorElement);
   assert.equal(editor.element, editorElement);
 });
 
 test('can create an editor via dom node reference from getElementById', (assert) => {
-  var editor = new Editor(document.getElementById('editor1'));
+  editor = new Editor(document.getElementById('editor1'));
   assert.equal(editor.element, editorElement);
 });
 


### PR DESCRIPTION
@mixonic for you

  * fixed many jshint failures
  * test for displaying toolbar, clicking the b, i, link, heading, subheading and blockquote buttons
  * misc tests for `editor#destroy` cleanup of views (specifically, removing the toolbar)
  * qunit `hasElement` and `hasNoElement` assertions
  * test helpers for dom interaction: `selectText(text, containingElement)`, `triggerEvent`, `triggerKeyEvent`
  * ~~bring in `KeyboardEvent` [polyfill](https://github.com/BladeRunnerJS/keyboard-event) for tests~~
  * skip 1 link test when running via phantom — I could not find a solid way to simulate a keyboard event in phantomjs

These tests now pass in all mac browsers *and* phantomjs.
There is an existing failing test in Firefox that is not from this PR.