### PR TITLE
Editor section tests

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -36,7 +36,10 @@ var defaults = {
   autofocus: true,
   post: null,
   serverHost: '',
-  stickyToolbar: !!('ontouchstart' in window),
+  // FIXME PhantomJS has 'ontouchstart' in window,
+  // causing the stickyToolbar to accidentally be auto-activated
+  // in tests
+  stickyToolbar: false, // !!('ontouchstart' in window),
   textFormatCommands: [
     new BoldCommand(),
     new ItalicCommand(),

--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -24,7 +24,10 @@ function getDirectionOfSelection(selection) {
 
 function getSelectionElement(selection) {
   selection = selection || window.getSelection();
-  var node = getDirectionOfSelection(selection) === SelectionDirection.LEFT_TO_RIGHT ? selection.anchorNode : selection.focusNode;
+  // FIXME it used to return `anchorNode` when selection direction is `LEFT_TO_RIGHT`,
+  // but I think that was a bug. In Safari and Chrome the selection usually had the
+  // same anchorNode and focusNode when selecting text, so it didn't matter.
+  var node = getDirectionOfSelection(selection) === SelectionDirection.LEFT_TO_RIGHT ? selection.focusNode : selection.anchorNode;
   return node && (node.nodeType === 3 ? node.parentNode : node);
 }
 

--- a/src/js/views/text-format-toolbar.js
+++ b/src/js/views/text-format-toolbar.js
@@ -30,9 +30,7 @@ function TextFormatToolbar(options) {
   });
 
   this.addEventListener(document, 'mouseup', () => {
-    setTimeout(function() {
-      handleTextSelection(toolbar);
-    });
+    handleTextSelection(toolbar);
   });
 
   this.addEventListener(document, 'keyup', (e) => {

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -32,94 +32,67 @@ function clickToolbarButton(name, assert) {
 }
 
 test('when text is highlighted, shows toolbar', (assert) => {
-  let done = assert.async();
-
-  setTimeout(() => {
-    assert.hasElement('.ck-toolbar', 'displays toolbar');
-    assert.hasElement('.ck-toolbar-btn', 'displays toolbar buttons');
-    let boldBtnSelector = '.ck-toolbar-btn[title="bold"]';
-    assert.hasElement(boldBtnSelector, 'has bold button');
-
-    done();
-  }, 10);
+  assert.hasElement('.ck-toolbar', 'displays toolbar');
+  assert.hasElement('.ck-toolbar-btn', 'displays toolbar buttons');
+  let boldBtnSelector = '.ck-toolbar-btn[title="bold"]';
+  assert.hasElement(boldBtnSelector, 'has bold button');
 });
 
 test('highlight text, click "bold" button bolds text', (assert) => {
-  let done = assert.async();
-
-  setTimeout(() => {
-    clickToolbarButton('bold', assert);
-    assert.hasElement('#editor b:contains(IS A)');
-
-    done();
-  }, 10);
+  clickToolbarButton('bold', assert);
+  assert.hasElement('#editor b:contains(IS A)');
 });
 
 test('highlight text, click "italic" button italicizes text', (assert) => {
-  let done = assert.async();
-
-  setTimeout(() => {
-    clickToolbarButton('italic', assert);
-    assert.hasElement('#editor i:contains(IS A)');
-
-    done();
-  }, 10);
+  clickToolbarButton('italic', assert);
+  assert.hasElement('#editor i:contains(IS A)');
 });
 
 test('highlight text, click "heading" button turns text into h2 header', (assert) => {
-  let done = assert.async();
-
-  setTimeout(() => {
-    clickToolbarButton('heading', assert);
-    assert.hasElement('#editor h2:contains(THIS IS A TEST)');
-
-    done();
-  }, 10);
+  clickToolbarButton('heading', assert);
+  assert.hasElement('#editor h2:contains(THIS IS A TEST)');
 });
 
 test('highlight text, click "subheading" button turns text into h3 header', (assert) => {
-  let done = assert.async();
-
-  setTimeout(() => {
-    clickToolbarButton('subheading', assert);
-    assert.hasElement('#editor h3:contains(THIS IS A TEST)');
-
-    done();
-  }, 10);
+  clickToolbarButton('subheading', assert);
+  assert.hasElement('#editor h3:contains(THIS IS A TEST)');
 });
 
 test('highlight text, click "quote" button turns text into blockquote', (assert) => {
-  let done = assert.async();
-
-  setTimeout(() => {
-    clickToolbarButton('quote', assert);
-    assert.hasElement('#editor blockquote:contains(THIS IS A TEST)');
-
-    done();
-  }, 10);
+  clickToolbarButton('quote', assert);
+  assert.hasElement('#editor blockquote:contains(THIS IS A TEST)');
 });
 
-test('highlight text, click "link" button shows input for URL, makes link', (assert) => {
-  let done = assert.async();
+// FIXME PhantomJS doesn't create keyboard events properly (they have no keyCode or which)
+// see https://bugs.webkit.org/show_bug.cgi?id=36423
+Helpers.skipInPhantom('highlight text, click "link" button shows input for URL, makes link', (assert) => {
+  clickToolbarButton('link', assert);
+  let input = assert.hasElement('.ck-toolbar-prompt input');
+  let url = 'http://google.com';
+  $(input).val(url);
+  Helpers.dom.triggerKeyEvent(input[0], 'keyup');
 
-  setTimeout(() => {
-    // FIXME PhantomJS doesn't create keyboard events properly (they have no keyCode or which)
-    // see https://bugs.webkit.org/show_bug.cgi?id=36423
-    let skippable = navigator.userAgent.indexOf('PhantomJS') !== -1;
-    if (skippable) {
-      assert.ok(true, 'Skipping test in phantomjs');
-      done();
-      return;
-    }
+  assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
+});
 
-    clickToolbarButton('link', assert);
-    let input = assert.hasElement('.ck-toolbar-prompt input');
-    let url = 'http://google.com';
-    $(input).val(url);
-    Helpers.dom.triggerKeyEvent(input[0], 'keyup');
+test('highlighting bold text shows bold button as active', (assert) => {
+  assert.hasNoElement(`.ck-toolbar-btn.active[title="bold"]`,
+                      'precond - bold button is not active');
+  clickToolbarButton('bold', assert);
 
-    assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
+  assert.hasElement(`.ck-toolbar-btn.active[title="bold"]`,
+                    'bold button is active after clicking it');
 
-    done();
-  }, 10);
+  Helpers.dom.clearSelection();
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  assert.hasNoElement('.ck-toolbar', 'toolbar is hidden');
+
+  Helpers.dom.selectText(selectedText, editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  assert.hasElement('.ck-toolbar', 'toolbar is shown again');
+
+  assert.hasElement(`.ck-toolbar-btn.active[title="bold"]`,
+                    'bold button is active when selecting bold text');
 });

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -1,0 +1,102 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+
+const { test, module } = QUnit;
+
+const newline = '\r\n';
+
+let fixture, editor, editorElement;
+const mobileDocWith1Section = [
+  [],
+  [
+    [1, "P", [
+      [[], 0, "only section"]
+    ]]
+  ]
+];
+const mobileDocWith2Sections = [
+  [],
+  [
+    [1, "P", [
+      [[], 0, "first section"]
+    ]],
+    [1, "P", [
+      [[], 0, "second section"]
+    ]]
+  ]
+];
+const mobileDocWith3Sections = [
+  [],
+  [
+    [1, "P", [
+      [[], 0, "first section"]
+    ]],
+    [1, "P", [
+      [[], 0, "second section"]
+    ]],
+    [1, "P", [
+      [[], 0, "third section"]
+    ]]
+  ]
+];
+
+module('Acceptance: Editor sections', {
+  beforeEach() {
+    fixture = document.getElementById('qunit-fixture');
+    editorElement = document.createElement('div');
+    editorElement.setAttribute('id', 'editor');
+    fixture.appendChild(editorElement);
+  },
+
+  afterEach() {
+    editor.destroy();
+  }
+});
+
+test('typing inserts section', (assert) => {
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Section});
+  assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
+
+  const text = 'new section';
+
+  Helpers.dom.moveCursorTo(editorElement);
+  document.execCommand('insertText', false, text + newline);
+
+  assert.equal($('#editor p').length, 2, 'has 2 paragraphs after typing return');
+  assert.hasElement(`#editor p:contains(${text})`, 'has first pargraph with "A"');
+  assert.hasElement('#editor p:contains(only section)', 'has correct second paragraph text');
+});
+
+test('deleting across 0 sections merges them', (assert) => {
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  assert.equal($('#editor p').length, 2, 'precond - has 2 sections to start');
+
+  const p0 = $('#editor p:eq(0)')[0],
+        p1 = $('#editor p:eq(1)')[0];
+
+  Helpers.dom.selectText('tion', p0, 'sec', p1);
+  document.execCommand('delete', false);
+
+  assert.equal($('#editor p').length, 1, 'has only 1 paragraph after deletion');
+  assert.hasElement('#editor p:contains(first second section)',
+                    'remaining paragraph has correct text');
+});
+
+test('deleting across 1 section removes it, joins the 2 boundary sections', (assert) => {
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith3Sections});
+  assert.equal($('#editor p').length, 3, 'precond - has 3 paragraphs to start');
+
+  const p0 = $('#editor p:eq(0)')[0],
+        p1 = $('#editor p:eq(1)')[0],
+        p2 = $('#editor p:eq(2)')[0];
+  assert.ok(p0 && p1 && p2, 'precond - paragraphs exist');
+
+  Helpers.dom.selectText('section', p0, 'third ', p2);
+
+  document.execCommand('delete', false);
+
+
+  assert.equal($('#editor p').length, 1, 'has only 1 paragraph after deletion');
+  assert.hasElement('#editor p:contains(first section)',
+                    'remaining paragraph has correct text');
+});

--- a/tests/helpers/skip-in-phantom.js
+++ b/tests/helpers/skip-in-phantom.js
@@ -1,0 +1,10 @@
+const { test } = QUnit;
+
+export default function(message, testFn) {
+  const isPhantom = navigator.userAgent.indexOf('PhantomJS') !== -1;
+  if (isPhantom) {
+    message = '[SKIPPED in PhantomJS] ' + message;
+    testFn = (assert) => assert.ok(true);
+  }
+  test(message, testFn);
+}

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -2,7 +2,9 @@ import registerAssertions from './helpers/assertions';
 registerAssertions();
 
 import DOMHelpers from './helpers/dom';
+import skipInPhantom from './helpers/skip-in-phantom';
 
 export default {
-  dom: DOMHelpers
+  dom: DOMHelpers,
+  skipInPhantom
 };


### PR DESCRIPTION
Tests that typing enter (`"\r\n"`) in a section breaks it into two, and that selecting text across sections and deleting merges them into one.

Tests pass in:
  * [X] safari
  * [X] phantom
  * [X] chrome
  * [ ] ~~FF~~ (will be fixed later)

Ready to merge