### PR TITLE
editor 'selection', 'selectionUpdated', and 'selectionEnded' events

### DIFF
--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -1,4 +1,4 @@
-export function detectParentNode(element, callback) {
+function detectParentNode(element, callback) {
   while (element) {
     const result = callback(element);
     if (result) {
@@ -15,3 +15,32 @@ export function detectParentNode(element, callback) {
     result: null
   };
 }
+
+function clearChildNodes(element) {
+  while (element.childNodes.length) {
+    element.removeChild(element.childNodes[0]);
+  }
+}
+
+// see https://github.com/webmodules/node-contains/blob/master/index.js
+function containsNode(parentNode, childNode) {
+  const isSame = () => parentNode === childNode;
+  const isContainedBy = () => {
+    const position = parentNode.compareDocumentPosition(childNode);
+    return !!(position & Node.DOCUMENT_POSITION_CONTAINED_BY);
+  };
+  return isSame() || isContainedBy();
+}
+
+function forEachChildNode(element, callback) {
+  for (let i=0; i<element.childNodes.length; i++) {
+    callback(element.childNodes[i]);
+  }
+}
+
+export {
+  detectParentNode,
+  containsNode,
+  clearChildNodes,
+  forEachChildNode
+};

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -31,17 +31,6 @@ function getEventTargetMatchingTag(tag, target, container) {
   }
 }
 
-function nodeIsDescendantOfElement(node, element) {
-  var parentNode = node.parentNode;
-  while(parentNode) {
-    if (parentNode === element) {
-      return true;
-    }
-    parentNode = parentNode.parentNode;
-  }
-  return false;
-}
-
 function elementContentIsEmpty(element) {
   var content = element && element.innerHTML;
   if (content) {
@@ -142,7 +131,6 @@ export {
   showElement,
   swapElements,
   getEventTargetMatchingTag,
-  nodeIsDescendantOfElement,
   elementContentIsEmpty,
   getElementRelativeOffset,
   getElementComputedStyleNumericProp,

--- a/src/js/utils/event-emitter.js
+++ b/src/js/utils/event-emitter.js
@@ -2,18 +2,18 @@
 // See also: https://github.com/allouis/minivents/blob/master/minivents.js
 
 var EventEmitter = {
-  on : function(type, handler){
+  on(type, handler){
     var events = this.__events = this.__events || {};
     events[type] = events[type] || [];
     events[type].push(handler);
   },
-  off : function(type, handler){
+  off(type, handler){
     var events = this.__events = this.__events || {};
     if (type in events) {
       events[type].splice(events[type].indexOf(handler), 1);
     }
   },
-  trigger : function(type) {
+  trigger(type) {
     var events = this.__events = this.__events || {};
     var eventForTypeCount, i;
     if (type in events) {

--- a/src/js/utils/keycodes.js
+++ b/src/js/utils/keycodes.js
@@ -1,4 +1,5 @@
 export default {
+  LEFT_ARROW: 37,
   BKSP  : 8,
   ENTER : 13,
   ESC   : 27,

--- a/src/js/utils/mixin.js
+++ b/src/js/utils/mixin.js
@@ -2,7 +2,8 @@ const CONSTRUCTOR_FN_NAME = 'constructor';
 
 export default function mixin(target, source) {
   target = target.prototype;
-  source = source.prototype;
+  // Fallback to just `source` to allow mixing in a plain object (pojo)
+  source = source.prototype || source;
 
   Object.getOwnPropertyNames(source).forEach((name) => {
     if (name !== CONSTRUCTOR_FN_NAME) {

--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -1,4 +1,4 @@
-import { nodeIsDescendantOfElement } from './element-utils';
+import { containsNode } from './dom-utils';
 
 // TODO: remove, pass in Editor's current block set
 var RootTags = [
@@ -10,6 +10,11 @@ var SelectionDirection = {
   RIGHT_TO_LEFT : 2,
   SAME_NODE     : 3
 };
+
+function clearSelection() {
+  // FIXME-IE ensure this works on IE 9. It works on IE10.
+  window.getSelection().removeAllRanges();
+}
 
 function getDirectionOfSelection(selection) {
   var node = selection.anchorNode;
@@ -29,6 +34,21 @@ function getSelectionElement(selection) {
   // same anchorNode and focusNode when selecting text, so it didn't matter.
   var node = getDirectionOfSelection(selection) === SelectionDirection.LEFT_TO_RIGHT ? selection.focusNode : selection.anchorNode;
   return node && (node.nodeType === 3 ? node.parentNode : node);
+}
+
+function isSelectionInElement(element) {
+  const selection = window.getSelection();
+  const { rangeCount, anchorNode, focusNode } = selection;
+
+  const range = (rangeCount > 0) && selection.getRangeAt(0);
+  const hasSelection = range && !range.collapsed;
+
+  if (hasSelection) {
+    return containsNode(element, anchorNode) &&
+      containsNode(element, focusNode);
+  } else {
+    return false;
+  }
 }
 
 function getSelectionBlockElement(selection) {
@@ -68,42 +88,21 @@ function tagsInSelection(selection) {
   return tags;
 }
 
-function selectionIsInElement(selection, element) {
-  var node = selection.anchorNode;
-  return node && nodeIsDescendantOfElement(node, element);
-}
-
-function selectionIsEditable(selection) {
-  var el = getSelectionBlockElement(selection);
-  return el && el.isContentEditable;
-}
-
 function restoreRange(range) {
+  clearSelection();
   var selection = window.getSelection();
-  selection.removeAllRanges();
   selection.addRange(range);
 }
 
 function selectNode(node) {
+  clearSelection();
+
   var range = document.createRange();
-  var selection = window.getSelection();
   range.setStart(node, 0);
   range.setEnd(node, node.length);
-  selection.removeAllRanges();
-  selection.addRange(range);
-}
 
-function setCursorIndexInElement(element, index) {
-  var range = document.createRange();
   var selection = window.getSelection();
-  range.setStart(element, index);
-  range.collapse(true);
-  selection.removeAllRanges();
   selection.addRange(range);
-}
-
-function setCursorToStartOfElement(element) {
-  setCursorIndexInElement(element, 0);
 }
 
 function getCursorOffsetInElement(element) {
@@ -120,5 +119,16 @@ function getCursorOffsetInElement(element) {
   return caretOffset;
 }
 
-export { getDirectionOfSelection, getSelectionElement, getSelectionBlockElement, getSelectionTagName,
-         getSelectionBlockTagName, tagsInSelection, selectionIsInElement, selectionIsEditable, restoreRange, selectNode, setCursorToStartOfElement, setCursorIndexInElement, getCursorOffsetInElement };
+export {
+  getDirectionOfSelection,
+  getSelectionElement,
+  getSelectionBlockElement,
+  getSelectionTagName,
+  getSelectionBlockTagName,
+  tagsInSelection,
+  restoreRange,
+  selectNode,
+  getCursorOffsetInElement,
+  clearSelection,
+  isSelectionInElement
+};

--- a/src/js/views/text-format-toolbar.js
+++ b/src/js/views/text-format-toolbar.js
@@ -1,55 +1,29 @@
 import Toolbar from './toolbar';
-import { inherit } from 'content-kit-utils';
-import { selectionIsEditable, selectionIsInElement } from '../utils/selection-utils';
-import Keycodes from '../utils/keycodes';
 
-function selectionIsEditableByToolbar(selection, toolbar) {
-  return selectionIsEditable(selection) && selectionIsInElement(selection, toolbar.rootElement);
-}
+export default class TextFormatToolbar extends Toolbar {
+  constructor(options={}) {
+    super(options);
 
-function handleTextSelection(toolbar) {
-  var selection = window.getSelection();
-  if (toolbar.sticky) {
-    toolbar.updateForSelection(selectionIsEditableByToolbar(selection, toolbar) ? selection : null);
-  } else {
-    if (selection.isCollapsed || selection.toString().trim() === '' || !selectionIsEditableByToolbar(selection, toolbar)) {
-      toolbar.hide();
-    } else {
-      toolbar.show();
-      toolbar.updateForSelection(selection);
+    this.editor.on('selection', () => this.handleSelection());
+    this.editor.on('selectionUpdated', () => this.handleSelection());
+    this.editor.on('selectionEnded', () => this.handleSelectionEnded());
+    this.editor.on('escapeKey', () => this.editor.cancelSelection());
+    this.addEventListener(window, 'resize', () => this.handleResize());
+  }
+
+  handleResize() {
+    if(this.isShowing) {
+      let activePromptRange = this.activePrompt && this.activePrompt.range;
+      this.positionToContent(activePromptRange ? activePromptRange : window.getSelection().getRangeAt(0));
     }
   }
+
+  handleSelection() {
+    this.show();
+    this.updateForSelection(window.getSelection());
+  }
+
+  handleSelectionEnded() {
+    this.hide();
+  }
 }
-
-function TextFormatToolbar(options) {
-  var toolbar = this;
-  Toolbar.call(this, options);
-  toolbar.rootElement = options.rootElement;
-  this.addEventListener(toolbar.rootElement, 'keyup', () => {
-    handleTextSelection(toolbar);
-  });
-
-  this.addEventListener(document, 'mouseup', () => {
-    handleTextSelection(toolbar);
-  });
-
-  this.addEventListener(document, 'keyup', (e) => {
-    var key = e.keyCode;
-    if (key === 116) { //F5
-      toolbar.toggleSticky();
-      handleTextSelection(toolbar);
-    } else if (!toolbar.sticky && key === Keycodes.ESC) {
-      toolbar.hide();
-    }
-  });
-
-  this.addEventListener(window, 'resize', () => {
-    if(!toolbar.sticky && toolbar.isShowing) {
-      var activePromptRange = toolbar.activePrompt && toolbar.activePrompt.range;
-      toolbar.positionToContent(activePromptRange ? activePromptRange : window.getSelection().getRangeAt(0));
-    }
-  });
-}
-inherit(TextFormatToolbar, Toolbar);
-
-export default TextFormatToolbar;

--- a/src/js/views/toolbar.js
+++ b/src/js/views/toolbar.js
@@ -1,6 +1,5 @@
 import View from './view';
 import ToolbarButton from './toolbar-button';
-import { inherit } from 'content-kit-utils';
 import { tagsInSelection } from '../utils/selection-utils';
 import { createDiv, swapElements, positionElementToRightOf, positionElementCenteredAbove } from '../utils/element-utils';
 
@@ -30,127 +29,104 @@ function updateButtonsForSelection(buttons, selection) {
   }
 }
 
-function Toolbar(options) {
-  options = options || {};
-  var toolbar = this;
-  var commands = options.commands;
-  var commandCount = commands && commands.length, i;
-  options.classNames = ['ck-toolbar'];
-  View.call(toolbar, options);
+class Toolbar extends View {
+  constructor(options={}) {
+    options.classNames = ['ck-toolbar'];
+    super(options);
 
-  toolbar.setSticky(options.sticky || false);
-  toolbar.setDirection(options.direction || ToolbarDirection.TOP);
-  toolbar.editor = options.editor || null;
-  toolbar.embedIntent = options.embedIntent || null;
-  toolbar.activePrompt = null;
-  toolbar.buttons = [];
+    let commands = options.commands;
+    let commandCount = commands && commands.length;
 
-  toolbar.contentElement = createDiv('ck-toolbar-content');
-  toolbar.promptContainerElement = createDiv('ck-toolbar-prompt');
-  toolbar.buttonContainerElement = createDiv('ck-toolbar-buttons');
-  toolbar.contentElement.appendChild(toolbar.promptContainerElement);
-  toolbar.contentElement.appendChild(toolbar.buttonContainerElement);
-  toolbar.element.appendChild(toolbar.contentElement);
+    this.setDirection(options.direction || ToolbarDirection.TOP);
+    this.editor = options.editor || null;
+    this.embedIntent = options.embedIntent || null;
+    this.activePrompt = null;
+    this.buttons = [];
 
-  for(i = 0; i < commandCount; i++) {
-    this.addCommand(commands[i]);
+    this.contentElement = createDiv('ck-toolbar-content');
+    this.promptContainerElement = createDiv('ck-toolbar-prompt');
+    this.buttonContainerElement = createDiv('ck-toolbar-buttons');
+    this.contentElement.appendChild(this.promptContainerElement);
+    this.contentElement.appendChild(this.buttonContainerElement);
+    this.element.appendChild(this.contentElement);
+
+    for(let i = 0; i < commandCount; i++) {
+      this.addCommand(commands[i]);
+    }
+
+    // Closes prompt if displayed when changing selection
+    this.addEventListener(document, 'mouseup', () => {
+      this.dismissPrompt();
+    });
   }
 
-  // Closes prompt if displayed when changing selection
-  this.addEventListener(document, 'mouseup', () => {
-    toolbar.dismissPrompt();
-  });
+  hide() {
+    if (super.hide()) {
+      let style = this.element.style;
+      style.left = '';
+      style.top = '';
+      this.dismissPrompt();
+    }
+  }
+
+  addCommand(command) {
+    command.editorContext = this.editor;
+    command.embedIntent = this.embedIntent;
+    let button = new ToolbarButton({command: command, toolbar: this});
+    this.buttons.push(button);
+    this.buttonContainerElement.appendChild(button.element);
+  }
+
+  displayPrompt(prompt) {
+    swapElements(this.promptContainerElement, this.buttonContainerElement);
+    this.promptContainerElement.appendChild(prompt.element);
+    prompt.show(() => {
+      this.dismissPrompt();
+      this.updateForSelection();
+    });
+    this.activePrompt = prompt;
+  }
+
+  dismissPrompt() {
+    let activePrompt = this.activePrompt;
+    if (activePrompt) {
+      activePrompt.hide();
+      swapElements(this.buttonContainerElement, this.promptContainerElement);
+      this.activePrompt = null;
+    }
+  }
+
+  updateForSelection(selection=window.getSelection()) {
+    if (!selection.isCollapsed) {
+      this.positionToContent(selection.getRangeAt(0));
+      updateButtonsForSelection(this.buttons, selection);
+    }
+  }
+
+  positionToContent(content) {
+    var directions = ToolbarDirection;
+    var positioningMethod, position, sideEdgeOffset;
+    switch(this.direction) {
+      case directions.RIGHT:
+        positioningMethod = positionElementToRightOf;
+        break;
+      default:
+        positioningMethod = positionElementCenteredAbove;
+    }
+    position = positioningMethod(this.element, content);
+    sideEdgeOffset = Math.min(Math.max(10, position.left), document.body.clientWidth - this.element.offsetWidth - 10);
+    this.contentElement.style.transform = 'translateX(' + (sideEdgeOffset - position.left) + 'px)';
+  }
+
+  setDirection(direction) {
+    this.direction = direction;
+    if (direction === ToolbarDirection.RIGHT) {
+      this.addClass('right');
+    } else {
+      this.removeClass('right');
+    }
+  }
 }
-inherit(Toolbar, View);
-
-Toolbar.prototype.hide = function() {
-  if (Toolbar._super.prototype.hide.call(this)) {
-    var style = this.element.style;
-    style.left = '';
-    style.top = '';
-    this.dismissPrompt();
-  }
-};
-
-Toolbar.prototype.addCommand = function(command) {
-  command.editorContext = this.editor;
-  command.embedIntent = this.embedIntent;
-  var button = new ToolbarButton({ command: command, toolbar: this });
-  this.buttons.push(button);
-  this.buttonContainerElement.appendChild(button.element);
-};
-
-Toolbar.prototype.displayPrompt = function(prompt) {
-  var toolbar = this;
-  swapElements(toolbar.promptContainerElement, toolbar.buttonContainerElement);
-  toolbar.promptContainerElement.appendChild(prompt.element);
-  prompt.show(function() {
-    toolbar.dismissPrompt();
-    toolbar.updateForSelection();
-  });
-  toolbar.activePrompt = prompt;
-};
-
-Toolbar.prototype.dismissPrompt = function() {
-  var toolbar = this;
-  var activePrompt = toolbar.activePrompt;
-  if (activePrompt) {
-    activePrompt.hide();
-    swapElements(toolbar.buttonContainerElement, toolbar.promptContainerElement);
-    toolbar.activePrompt = null;
-  }
-};
-
-Toolbar.prototype.updateForSelection = function(selection) {
-  var toolbar = this;
-  selection = selection || window.getSelection();
-  if (toolbar.sticky) {
-    updateButtonsForSelection(toolbar.buttons, selection);
-  } else if (!selection.isCollapsed) {
-    toolbar.positionToContent(selection.getRangeAt(0));
-    updateButtonsForSelection(toolbar.buttons, selection);
-  }
-};
-
-Toolbar.prototype.positionToContent = function(content) {
-  var directions = ToolbarDirection;
-  var positioningMethod, position, sideEdgeOffset;
-  switch(this.direction) {
-    case directions.RIGHT:
-      positioningMethod = positionElementToRightOf;
-      break;
-    default:
-      positioningMethod = positionElementCenteredAbove;
-  }
-  position = positioningMethod(this.element, content);
-  sideEdgeOffset = Math.min(Math.max(10, position.left), document.body.clientWidth - this.element.offsetWidth - 10);
-  this.contentElement.style.transform = 'translateX(' + (sideEdgeOffset - position.left) + 'px)';
-};
-
-Toolbar.prototype.setDirection = function(direction) {
-  this.direction = direction;
-  if (direction === ToolbarDirection.RIGHT) {
-    this.addClass('right');
-  } else {
-    this.removeClass('right');
-  }
-};
-
-Toolbar.prototype.setSticky = function(sticky) {
-  this.sticky = sticky;
-  if (sticky) {
-    this.addClass('sticky');
-    this.element.removeAttribute('style'); // clears any prior positioning
-    this.show();
-  } else {
-    this.removeClass('sticky');
-    this.hide();
-  }
-};
-
-Toolbar.prototype.toggleSticky = function() {
-  this.setSticky(!this.sticky);
-};
 
 Toolbar.Direction = ToolbarDirection;
 

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -32,67 +32,119 @@ function clickToolbarButton(name, assert) {
 }
 
 test('when text is highlighted, shows toolbar', (assert) => {
-  assert.hasElement('.ck-toolbar', 'displays toolbar');
-  assert.hasElement('.ck-toolbar-btn', 'displays toolbar buttons');
-  let boldBtnSelector = '.ck-toolbar-btn[title="bold"]';
-  assert.hasElement(boldBtnSelector, 'has bold button');
+  let done = assert.async();
+
+  setTimeout(() => {
+    assert.hasElement('.ck-toolbar', 'displays toolbar');
+    assert.hasElement('.ck-toolbar-btn', 'displays toolbar buttons');
+    let boldBtnSelector = '.ck-toolbar-btn[title="bold"]';
+    assert.hasElement(boldBtnSelector, 'has bold button');
+
+    done();
+  });
 });
 
 test('highlight text, click "bold" button bolds text', (assert) => {
-  clickToolbarButton('bold', assert);
-  assert.hasElement('#editor b:contains(IS A)');
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('bold', assert);
+    assert.hasElement('#editor b:contains(IS A)');
+
+    done();
+  });
 });
 
 test('highlight text, click "italic" button italicizes text', (assert) => {
-  clickToolbarButton('italic', assert);
-  assert.hasElement('#editor i:contains(IS A)');
+  let done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('italic', assert);
+    assert.hasElement('#editor i:contains(IS A)');
+
+    done();
+  });
 });
 
 test('highlight text, click "heading" button turns text into h2 header', (assert) => {
-  clickToolbarButton('heading', assert);
-  assert.hasElement('#editor h2:contains(THIS IS A TEST)');
+  const done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('heading', assert);
+    assert.hasElement('#editor h2:contains(THIS IS A TEST)');
+
+    done();
+  });
 });
 
 test('highlight text, click "subheading" button turns text into h3 header', (assert) => {
-  clickToolbarButton('subheading', assert);
-  assert.hasElement('#editor h3:contains(THIS IS A TEST)');
+  const done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('subheading', assert);
+    assert.hasElement('#editor h3:contains(THIS IS A TEST)');
+
+    done();
+  });
 });
 
 test('highlight text, click "quote" button turns text into blockquote', (assert) => {
-  clickToolbarButton('quote', assert);
-  assert.hasElement('#editor blockquote:contains(THIS IS A TEST)');
+  const done = assert.async();
+
+  setTimeout(() => {
+    clickToolbarButton('quote', assert);
+    assert.hasElement('#editor blockquote:contains(THIS IS A TEST)');
+
+    done();
+  });
 });
 
 // FIXME PhantomJS doesn't create keyboard events properly (they have no keyCode or which)
 // see https://bugs.webkit.org/show_bug.cgi?id=36423
 Helpers.skipInPhantom('highlight text, click "link" button shows input for URL, makes link', (assert) => {
-  clickToolbarButton('link', assert);
-  let input = assert.hasElement('.ck-toolbar-prompt input');
-  let url = 'http://google.com';
-  $(input).val(url);
-  Helpers.dom.triggerKeyEvent(input[0], 'keyup');
+  const done = assert.async();
 
-  assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
+  setTimeout(() => {
+    clickToolbarButton('link', assert);
+    let input = assert.hasElement('.ck-toolbar-prompt input');
+    let url = 'http://google.com';
+    $(input).val(url);
+    Helpers.dom.triggerKeyEvent(input[0], 'keyup');
+
+    assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
+
+    done();
+  });
 });
 
 test('highlighting bold text shows bold button as active', (assert) => {
-  assert.hasNoElement(`.ck-toolbar-btn.active[title="bold"]`,
-                      'precond - bold button is not active');
-  clickToolbarButton('bold', assert);
+  const done = assert.async();
 
-  assert.hasElement(`.ck-toolbar-btn.active[title="bold"]`,
-                    'bold button is active after clicking it');
+  setTimeout(() => {
+    assert.hasNoElement(`.ck-toolbar-btn.active[title="bold"]`,
+                        'precond - bold button is not active');
+    clickToolbarButton('bold', assert);
 
-  Helpers.dom.clearSelection();
-  Helpers.dom.triggerEvent(document, 'mouseup');
+    assert.hasElement(`.ck-toolbar-btn.active[title="bold"]`,
+                      'bold button is active after clicking it');
 
-  assert.hasNoElement('.ck-toolbar', 'toolbar is hidden');
+    Helpers.dom.clearSelection();
+    Helpers.dom.triggerEvent(document, 'mouseup');
 
-  Helpers.dom.selectText(selectedText, editorElement);
-  Helpers.dom.triggerEvent(document, 'mouseup');
+    setTimeout(() => {
+      assert.hasNoElement('.ck-toolbar', 'toolbar is hidden');
 
-  assert.hasElement('.ck-toolbar', 'toolbar is shown again');
+      Helpers.dom.selectText(selectedText, editorElement);
+      Helpers.dom.triggerEvent(document, 'mouseup');
 
-  assert.hasElement(`.ck-toolbar-btn.active[title="bold"]`,
-                    'bold button is active when selecting bold text');
+      setTimeout(() => {
+        assert.hasElement('.ck-toolbar', 'toolbar is shown again');
+
+        assert.hasElement(`.ck-toolbar-btn.active[title="bold"]`,
+                          'bold button is active when selecting bold text');
+
+        done();
+      });
+    });
+  });
 });

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -1,26 +1,10 @@
 const TEXT_NODE = 3;
-const ENTER_KEY = 13;
-const LEFT_ARROW = 37;
-const KEY_CODES = {
-  ENTER_KEY,
-  LEFT_ARROW
-};
 
-function moveCursorTo(element, offset=0) {
-  let range = document.createRange();
-  range.setStart(element, offset);
-  range.setEnd(element, offset);
-
-  let selection = window.getSelection();
-  selection.removeAllRanges();
-  selection.addRange(range);
-}
-
-function clearSelection() {
-  window.getSelection().removeAllRanges();
-}
+import { clearSelection } from 'content-kit-editor/utils/selection-utils';
+import KEY_CODES from 'content-kit-editor/utils/keycodes';
 
 function walkDOMUntil(topNode, conditionFn=() => {}) {
+  if (!topNode) { throw new Error('Cannot call walkDOMUntil without a node'); }
   let stack = [topNode];
   let currentElement;
 
@@ -38,12 +22,13 @@ function walkDOMUntil(topNode, conditionFn=() => {}) {
 }
 
 function selectRange(startNode, startOffset, endNode, endOffset) {
+  clearSelection();
+
   const range = document.createRange();
   range.setStart(startNode, startOffset);
   range.setEnd(endNode, endOffset);
 
   const selection = window.getSelection();
-  if (selection.rangeCount > 0) { selection.removeAllRanges(); }
   selection.addRange(range);
 }
 
@@ -67,6 +52,10 @@ function selectText(startText,
   const startOffset = startTextNode.textContent.indexOf(startText),
         endOffset   = endTextNode.textContent.indexOf(endText) + endText.length;
   selectRange(startTextNode, startOffset, endTextNode, endOffset);
+}
+
+function moveCursorTo(element, offset=0) {
+  selectRange(element, offset, element, offset);
 }
 
 function triggerEvent(node, eventType) {
@@ -102,7 +91,7 @@ function createKeyEvent(eventType, keyCode) {
   return oEvent;
 }
 
-function triggerKeyEvent(node, eventType, keyCode=KEY_CODES.ENTER_KEY) {
+function triggerKeyEvent(node, eventType, keyCode=KEY_CODES.ENTER) {
   let oEvent = createKeyEvent(eventType, keyCode);
   node.dispatchEvent(oEvent);
 }
@@ -112,6 +101,5 @@ export default {
   selectText,
   clearSelection,
   triggerEvent,
-  triggerKeyEvent,
-  KEY_CODES
+  triggerKeyEvent
 };

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -2,6 +2,7 @@ const { module, test } = QUnit;
 
 import Helpers from '../../test-helpers';
 import { Editor } from 'content-kit-editor';
+import { containsNode } from 'content-kit-editor/utils/dom-utils';
 let editorElement, editor;
 
 module('Unit: Editor: Card Lifecycle', {
@@ -28,7 +29,7 @@ test('rendering a mobiledoc for editing calls card#setup', (assert) => {
     name: 'test-card',
     display: {
       setup(element, options, env, setupPayload) {
-        assert.ok(editorElement.contains(element),
+        assert.ok(containsNode(editorElement, element),
                   'card element is part of the editor element');
         assert.deepEqual(payload, setupPayload,
                          'the payload is passed to the card');
@@ -101,7 +102,7 @@ test('rendered card can fire edit hook to enter editing mode', (assert) => {
     },
     edit: {
       setup(element, options, env, setupPayload) {
-        assert.ok(editorElement.contains(element),
+        assert.ok(containsNode(editorElement, element),
                   'card element is part of the editor element');
         assert.deepEqual(payload, setupPayload,
                          'the payload is passed to the card');

--- a/tests/unit/editor/editor-destroy-test.js
+++ b/tests/unit/editor/editor-destroy-test.js
@@ -4,22 +4,27 @@ import Helpers from '../../test-helpers';
 import { Editor } from 'content-kit-editor';
 
 let editor;
-let fixture;
+let editorElement;
 
 module('Unit: Editor #destroy', {
   beforeEach() {
-    fixture = $('#qunit-fixture');
-    fixture.html('the editor');
-    editor = new Editor(fixture[0]);
+    let fixture = $('#qunit-fixture')[0];
+    editorElement = document.createElement('div');
+    editorElement.innerHTML = 'HELLO';
+    fixture.appendChild(editorElement);
+    editor = new Editor(editorElement);
   },
   afterEach() {
+    if (editor) {
+      editor.destroy();
+    }
   }
 });
 
 test('removes toolbar from DOM', (assert) => {
   let done = assert.async();
 
-  Helpers.dom.selectText('the editor', fixture[0]);
+  Helpers.dom.selectText('HELLO', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
 
   setTimeout(() => {

--- a/tests/unit/editor/editor-events-test.js
+++ b/tests/unit/editor/editor-events-test.js
@@ -1,0 +1,99 @@
+const { module, test } = QUnit;
+import Helpers from '../../test-helpers';
+
+import { Editor } from 'content-kit-editor';
+
+let editor, editorElement;
+let triggered = [];
+
+module('Unit: Editor: events', {
+  beforeEach() {
+    editorElement = document.createElement('div');
+    editorElement.innerHTML = 'this is the editor';
+    document.getElementById('qunit-fixture').appendChild(editorElement);
+
+    editor = new Editor(editorElement);
+    editor.trigger = (name) => triggered.push(name);
+  },
+
+  afterEach() {
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+    triggered = [];
+  }
+});
+
+function assertTriggered(name, assert, message=`triggers ${name}`) {
+  assert.ok(triggered.indexOf(name) > -1, message);
+}
+
+function assertNotTriggered(name, assert, message=`does not trigger ${name}`) {
+  assert.ok(triggered.indexOf(name) === -1, message);
+}
+
+test('mouseup when text is selected triggers "selection" event', (assert) => {
+  const done = assert.async();
+
+  Helpers.dom.selectText('the editor', editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  assertNotTriggered('selection', assert, 'no selection before timeout');
+
+  setTimeout(() => {
+    assertTriggered('selection', assert, 'no selection before timeout');
+
+    done();
+  });
+});
+
+test('multiple mouseups when text is selected trigger "selectionUpdated" event', (assert) => {
+  const done = assert.async();
+
+  Helpers.dom.selectText('the editor', editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    // mouseup again
+    Helpers.dom.triggerEvent(document, 'mouseup');
+
+    setTimeout(() => {
+      assertTriggered('selectionUpdated', assert);
+
+      done();
+    });
+  });
+});
+
+test('mouseup when no text is selected triggers no events', (assert) => {
+  const done = assert.async();
+
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    assertNotTriggered('selection', assert);
+    assertNotTriggered('selectionUpdated', assert);
+    assertNotTriggered('selectionEnded', assert);
+
+    done();
+  });
+});
+
+test('mouseup after text was selected triggers "selectionEnded" event', (assert) => {
+  const done = assert.async();
+
+  Helpers.dom.selectText('the editor', editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    Helpers.dom.clearSelection();
+    Helpers.dom.triggerEvent(document, 'mouseup');
+
+    setTimeout(() => {
+      assertTriggered('selectionEnded', assert);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Move browser event handling to be the editor's responsibility, let its internals react to the editor's semantic events. Lots of cleanup of unused utils.

 * Cleanup editor (-> class), remove unused utils
 * classify Toolbar, TextFormatToolbar
  * add `escapeKey` event