### PR TITLE
Post, Section, Markers

### DIFF
--- a/src/js/models/image.js
+++ b/src/js/models/image.js
@@ -1,6 +1,8 @@
+export const IMAGE_SECTION_TYPE = 'image-section';
+
 export default class Image {
   constructor() {
-    this.type = 'imageSection';
+    this.type = IMAGE_SECTION_TYPE;
     this.src = null;
   }
 }

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -1,0 +1,70 @@
+export const MARKUP_TYPES = ['b', 'a', 'i', 'em', 'strong'];
+
+export default class Marker {
+  constructor(value='', markups=[]) {
+    this.value = value;
+    this.markups = [];
+    markups.forEach(m => this.addMarkup(m));
+  }
+
+  get length() {
+    return this.value.length;
+  }
+
+  truncateFrom(offset) {
+    this.value = this.value.substr(0, offset);
+  }
+
+  truncateTo(offset) {
+    this.value = this.value.substr(offset);
+  }
+
+  addMarkup(markup) {
+    // simple markup, no attributes
+    if (typeof markup === 'string') {
+      markup = {type: markup};
+    }
+    let {type, attributes} = markup;
+    type = type.toLowerCase();
+
+    if (MARKUP_TYPES.indexOf(type) === -1) {
+      throw new Error(`Cannot add markup of type ${type}`);
+    }
+
+    markup = {type, attributes};
+
+    if (!this.hasMarkup(type)) {
+      this.markups.push(markup);
+    }
+  }
+
+  hasMarkup(type) {
+    for (let i=0; i<this.markups.length; i++) {
+      if (this.markups[i].type === type) {
+        return this.markups[i];
+      }
+    }
+  }
+
+  getMarkup(type) {
+    return this.hasMarkup(type);
+  }
+
+  join(other) {
+    const joined = new Marker(this.value + other.value);
+    this.markups.forEach(m => joined.addMarkup(m));
+    other.markups.forEach(m => joined.addMarkup(m));
+
+    return joined;
+  }
+
+  split(offset) {
+    const [m1, m2] = [
+      new Marker(this.value.substr(0, offset)),
+      new Marker(this.value.substr(offset))
+    ];
+    this.markups.forEach(m => {m1.addMarkup(m); m2.addMarkup(m);});
+
+    return [m1, m2];
+  }
+}

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -25,18 +25,11 @@ const Marker = class Marker {
   }
 
   addMarkup(markup) {
-    // simple markup, no attributes
-    if (typeof markup === 'string') {
-      markup = {tagName: markup};
-    }
-    let {tagName, attributes} = markup;
-    tagName = tagName.toLowerCase();
+    const {tagName} = markup;
 
     if (MARKUP_TAG_NAMES.indexOf(tagName) === -1) {
       throw new Error(`Cannot add markup of tagName ${tagName}`);
     }
-
-    markup = {tagName, attributes};
 
     if (!this.hasMarkup(tagName)) {
       this.markups.push(markup);

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -1,5 +1,4 @@
-export const MARKUP_TAG_NAMES = ['b', 'a', 'i', 'em', 'strong'];
-const MARKER_TYPE = 'marker';
+export const MARKER_TYPE = 'marker';
 
 import { detect } from 'content-kit-editor/utils/array-utils';
 
@@ -9,7 +8,9 @@ const Marker = class Marker {
     this.markups = [];
     this.type = MARKER_TYPE;
 
-    markups.forEach(m => this.addMarkup(m));
+    if (markups && markups.length) {
+      markups.forEach(m => this.addMarkup(m));
+    }
   }
 
   get length() {
@@ -25,15 +26,7 @@ const Marker = class Marker {
   }
 
   addMarkup(markup) {
-    const {tagName} = markup;
-
-    if (MARKUP_TAG_NAMES.indexOf(tagName) === -1) {
-      throw new Error(`Cannot add markup of tagName ${tagName}`);
-    }
-
-    if (!this.hasMarkup(tagName)) {
-      this.markups.push(markup);
-    }
+    this.markups.push(markup);
   }
 
   hasMarkup(tagName) {
@@ -61,6 +54,32 @@ const Marker = class Marker {
     this.markups.forEach(m => {m1.addMarkup(m); m2.addMarkup(m);});
 
     return [m1, m2];
+  }
+
+  get openedMarkups() {
+    if (!this.previousSibling) {
+      return this.markups.slice();
+    }
+    let i;
+    for (i=0; i<this.markups.length; i++) {
+      if (this.markups[i] !== this.previousSibling.markups[i]) {
+        return this.markups.slice(i);
+      }
+    }
+    return [];
+  }
+
+  get closedMarkups() {
+    if (!this.nextSibling) {
+      return this.markups.slice();
+    }
+    let i;
+    for (i=0; i<this.markups.length; i++) {
+      if (this.markups[i] !== this.nextSibling.markups[i]) {
+        return this.markups.slice(i);
+      }
+    }
+    return [];
   }
 };
 

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -81,6 +81,21 @@ const Marker = class Marker {
     }
     return [];
   }
+
+  // FIXME this should be implemented as a linked list
+  get nextSibling() {
+    let index = this.section.markers.indexOf(this);
+    if (index > -1 && index < this.section.markers.length-1) {
+      return this.section.markers[index + 1];
+    }
+  }
+
+  get previousSibling() {
+    let index = this.section.markers.indexOf(this);
+    if (index > 0) {
+      return this.section.markers[index - 1];
+    }
+  }
 };
 
 export default Marker;

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -1,9 +1,14 @@
 export const MARKUP_TYPES = ['b', 'a', 'i', 'em', 'strong'];
+const MARKER_TYPE = 'marker';
 
-export default class Marker {
+import { detect } from 'content-kit-editor/utils/array-utils';
+
+const Marker = class Marker {
   constructor(value='', markups=[]) {
     this.value = value;
     this.markups = [];
+    this.type = MARKER_TYPE;
+
     markups.forEach(m => this.addMarkup(m));
   }
 
@@ -39,11 +44,7 @@ export default class Marker {
   }
 
   hasMarkup(type) {
-    for (let i=0; i<this.markups.length; i++) {
-      if (this.markups[i].type === type) {
-        return this.markups[i];
-      }
-    }
+    return detect(this.markups, markup => markup.type === type);
   }
 
   getMarkup(type) {
@@ -67,4 +68,6 @@ export default class Marker {
 
     return [m1, m2];
   }
-}
+};
+
+export default Marker;

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -1,4 +1,4 @@
-export const MARKUP_TYPES = ['b', 'a', 'i', 'em', 'strong'];
+export const MARKUP_TAG_NAMES = ['b', 'a', 'i', 'em', 'strong'];
 const MARKER_TYPE = 'marker';
 
 import { detect } from 'content-kit-editor/utils/array-utils';
@@ -27,28 +27,29 @@ const Marker = class Marker {
   addMarkup(markup) {
     // simple markup, no attributes
     if (typeof markup === 'string') {
-      markup = {type: markup};
+      markup = {tagName: markup};
     }
-    let {type, attributes} = markup;
-    type = type.toLowerCase();
+    let {tagName, attributes} = markup;
+    tagName = tagName.toLowerCase();
 
-    if (MARKUP_TYPES.indexOf(type) === -1) {
-      throw new Error(`Cannot add markup of type ${type}`);
+    if (MARKUP_TAG_NAMES.indexOf(tagName) === -1) {
+      throw new Error(`Cannot add markup of tagName ${tagName}`);
     }
 
-    markup = {type, attributes};
+    markup = {tagName, attributes};
 
-    if (!this.hasMarkup(type)) {
+    if (!this.hasMarkup(tagName)) {
       this.markups.push(markup);
     }
   }
 
-  hasMarkup(type) {
-    return detect(this.markups, markup => markup.type === type);
+  hasMarkup(tagName) {
+    tagName = tagName.toLowerCase();
+    return detect(this.markups, markup => markup.tagName === tagName);
   }
 
-  getMarkup(type) {
-    return this.hasMarkup(type);
+  getMarkup(tagName) {
+    return this.hasMarkup(tagName);
   }
 
   join(other) {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -2,13 +2,13 @@ export const DEFAULT_TAG_NAME = 'p';
 export const SECTION_TAG_NAMES = [
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div'
 ];
-const SECTION_TYPE = 'section';
+export const MARKUP_SECTION_TYPE = 'markup-section';
 
-const Section = class Section {
-  constructor(tagName=DEFAULT_TAG_NAME, markers=[]) {
-    this.markers = [];
-    this.tagName = tagName;
-    this.type = SECTION_TYPE;
+export default class Section {
+  constructor(tagName, markers=[]) {
+    this.markers = markers;
+    this.tagName = tagName || DEFAULT_TAG_NAME;
+    this.type = MARKUP_SECTION_TYPE;
 
     markers.forEach(m => this.appendMarker(m));
   }
@@ -39,8 +39,8 @@ const Section = class Section {
     right.push(rightMiddle);
 
     return [
-      new Section(this.tagName, left),
-      new Section(this.tagName, right)
+      new this.constructor(this.tagName, left),
+      new this.constructor(this.tagName, right)
     ];
   }
 
@@ -64,6 +64,4 @@ const Section = class Section {
     }
     return this.markers[i-1];
   }
-};
-
-export default Section;
+}

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -1,12 +1,12 @@
 export const DEFAULT_TAG_NAME = 'p';
-export const SECTION_TAG_NAMES = [
-  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div'
+export const VALID_MARKUP_SECTION_TAGNAMES = [
+  'p', 'h3', 'h2', 'h1', 'blockquote', 'ul', 'ol'
 ];
 export const MARKUP_SECTION_TYPE = 'markup-section';
 
 export default class Section {
   constructor(tagName, markers=[]) {
-    this.markers = markers;
+    this.markers = [];
     this.tagName = tagName || DEFAULT_TAG_NAME;
     this.type = MARKUP_SECTION_TYPE;
 

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -14,6 +14,7 @@ export default class Section {
   }
 
   appendMarker(marker) {
+    marker.section = this;
     this.markers.push(marker);
   }
 

--- a/src/js/models/markup.js
+++ b/src/js/models/markup.js
@@ -1,0 +1,9 @@
+const MARKUP_TYPE = 'markup';
+
+export default class Markup {
+  constructor(tagName, attributes={}) {
+    this.tagName = tagName.toLowerCase();
+    this.attributes = attributes;
+    this.type = MARKUP_TYPE;
+  }
+}

--- a/src/js/models/markup.js
+++ b/src/js/models/markup.js
@@ -1,9 +1,21 @@
-const MARKUP_TYPE = 'markup';
+export const MARKUP_TYPE = 'markup';
+export const VALID_MARKUP_TAGNAMES = [
+  'b',
+  'i',
+  'strong',
+  'em',
+  'a',
+  'li'
+];
 
 export default class Markup {
-  constructor(tagName, attributes={}) {
+  constructor(tagName, attributes=[]) {
     this.tagName = tagName.toLowerCase();
     this.attributes = attributes;
     this.type = MARKUP_TYPE;
+
+    if (VALID_MARKUP_TAGNAMES.indexOf(this.tagName) === -1) {
+      throw new Error(`Cannot create markup of tagName ${tagName}`);
+    }
   }
 }

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -1,7 +1,9 @@
+export const POST_TYPE = 'post';
+
 // FIXME: making sections a linked-list would greatly improve this
 export default class Post {
   constructor() {
-    this.type = 'post';
+    this.type = POST_TYPE;
     this.sections = [];
   }
   appendSection(section) {

--- a/src/js/models/section.js
+++ b/src/js/models/section.js
@@ -1,12 +1,15 @@
-export const DEFAULT_TYPE = 'p';
-export const SECTION_TYPES = [
+export const DEFAULT_TAG_NAME = 'p';
+export const SECTION_TAG_NAMES = [
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div'
 ];
+const SECTION_TYPE = 'section';
 
 const Section = class Section {
-  constructor(type=DEFAULT_TYPE, markers=[]) {
+  constructor(tagName=DEFAULT_TAG_NAME, markers=[]) {
     this.markers = [];
-    this.type = type;
+    this.tagName = tagName;
+    this.type = SECTION_TYPE;
+
     markers.forEach(m => this.appendMarker(m));
   }
 
@@ -36,8 +39,8 @@ const Section = class Section {
     right.push(rightMiddle);
 
     return [
-      new Section(this.type, left),
-      new Section(this.type, right)
+      new Section(this.tagName, left),
+      new Section(this.tagName, right)
     ];
   }
 

--- a/src/js/models/section.js
+++ b/src/js/models/section.js
@@ -1,0 +1,66 @@
+export const DEFAULT_TYPE = 'p';
+export const SECTION_TYPES = [
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div'
+];
+
+const Section = class Section {
+  constructor(type=DEFAULT_TYPE, markers=[]) {
+    this.markers = [];
+    this.type = type;
+    markers.forEach(m => this.appendMarker(m));
+  }
+
+  appendMarker(marker) {
+    this.markers.push(marker);
+  }
+
+  /**
+   * @return {Array} 2 new sections
+   */
+  split(offset) {
+    let left = [], right = [], middle;
+
+    middle = this.markerContaining(offset);
+    const middleIndex = this.markers.indexOf(middle);
+
+    for (let i=0; i<this.markers.length; i++) {
+      if (i < middleIndex) { left.push(this.markers[i]); }
+      if (i > middleIndex) { right.push(this.markers[i]); }
+    }
+
+    let leftLength = left.reduce((prev, cur) => prev + cur.length, 0);
+    let middleOffset = offset - leftLength;
+
+    let [leftMiddle, rightMiddle] = middle.split(middleOffset);
+    left.push(leftMiddle);
+    right.push(rightMiddle);
+
+    return [
+      new Section(this.type, left),
+      new Section(this.type, right)
+    ];
+  }
+
+  /**
+   * A marker contains this offset if:
+   *   * The offset is between the marker's start and end
+   *   * it is the first marker and the offset is 0
+   *   * it is the last marker and the offset is >= total length of all the markers
+   *   * the offset is between two markers and it is the left marker (right-inclusive)
+   *
+   * @return {Marker} The marker that contains this offset
+   */
+  markerContaining(offset) {
+    var length=0, i=0;
+
+    if (offset === 0) { return this.markers[0]; }
+
+    while (length < offset && i < this.markers.length) {
+      length += this.markers[i].length;
+      i++;
+    }
+    return this.markers[i-1];
+  }
+};
+
+export default Section;

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -143,7 +143,7 @@ NewHTMLParser.prototype = {
       var tagName = sectionElement.tagName;
       // <p> <h2>, etc
       if (MARKUP_SECTION_TAG_NAMES.indexOf(tagName) !== -1) {
-        section = postBuilder.generateSection(tagName, readAttributes(sectionElement));
+        section = postBuilder.generateMarkupSection(tagName, readAttributes(sectionElement));
         var node = sectionElement.firstChild;
         while (node) {
           parseMarkers(section, postBuilder, node);
@@ -154,7 +154,7 @@ NewHTMLParser.prototype = {
         if (previousSection && previousSection.isGenerated) {
           section = previousSection;
         } else {
-          section = postBuilder.generateSection('P', {}, true);
+          section = postBuilder.generateMarkupSection('P', {}, true);
         }
         parseMarkers(section, postBuilder, sectionElement);
       }
@@ -163,7 +163,7 @@ NewHTMLParser.prototype = {
       if (previousSection && previousSection.isGenerated) {
         section = previousSection;
       } else {
-        section = postBuilder.generateSection('P', {}, true);
+        section = postBuilder.generateMarkupSection('P', {}, true);
       }
       parseMarkers(section, postBuilder, sectionElement);
       break;

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -79,23 +79,23 @@ function parseMarkers(section, postBuilder, topNode) {
 
     if (currentNode.firstChild) {
       if (isValidMarkerElement(currentNode) && text !== null) {
-        section.markers.push(postBuilder.generateMarker(markups.slice(), text));
+        section.appendMarker(postBuilder.generateMarker(markups.slice(), text));
         text = null;
       }
       currentNode = currentNode.firstChild;
     } else if (currentNode.nextSibling) {
       if (currentNode === topNode) {
-        section.markers.push(postBuilder.generateMarker(markups.slice(), text));
+        section.appendMarker(postBuilder.generateMarker(markups.slice(), text));
         break;
       } else {
         currentNode = currentNode.nextSibling;
         if (currentNode.nodeType === ELEMENT_NODE && isValidMarkerElement(currentNode) && text !== null) {
-          section.markers.push(postBuilder.generateMarker(markups.slice(), text));
+          section.appendMarker(postBuilder.generateMarker(markups.slice(), text));
           text = null;
         }
       }
     } else {
-      section.markers.push(postBuilder.generateMarker(markups.slice(), text));
+      section.appendMarker(postBuilder.generateMarker(markups.slice(), text));
 
       while (currentNode && !currentNode.nextSibling && currentNode !== topNode) {
         currentNode = currentNode.parentNode;

--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -82,7 +82,7 @@ export default class MobiledocParser {
       this.markups.push(this.markerTypes[index]);
     });
     const marker = this.builder.generateMarker(this.markups.slice(), value);
-    section.markers.push(marker);
+    section.appendMarker(marker);
     this.markups = this.markups.slice(0, this.markups.length-closeCount);
   }
 }

--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -66,7 +66,7 @@ export default class MobiledocParser {
   parseMarkupSection([type, tagName, markers], post) {
     const attributes = null;
     const isGenerated = false;
-    const section = this.builder.generateSection(tagName, attributes, isGenerated);
+    const section = this.builder.generateMarkupSection(tagName, attributes, isGenerated);
 
     post.appendSection(section);
     this.parseMarkers(markers, section);

--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -18,6 +18,7 @@ export default class MobiledocParser {
 
     const post = this.builder.generatePost();
 
+    this.markups = [];
     this.markerTypes = this.parseMarkerTypes(markerTypes);
     this.parseSections(sections, post);
 
@@ -29,7 +30,7 @@ export default class MobiledocParser {
   }
 
   parseMarkerType([tagName, attributes]) {
-    return this.builder.generateMarkerType(tagName, attributes);
+    return this.builder.generateMarkup(tagName, attributes);
   }
 
   parseSections(sections, post) {
@@ -77,8 +78,11 @@ export default class MobiledocParser {
   }
 
   parseMarker([markerTypeIndexes, closeCount, value], section) {
-    const markerTypes = markerTypeIndexes.map(index => this.markerTypes[index]);
-    const marker = this.builder.generateMarker(markerTypes, closeCount, value);
+    markerTypeIndexes.forEach(index => {
+      this.markups.push(this.markerTypes[index]);
+    });
+    const marker = this.builder.generateMarker(this.markups.slice(), value);
     section.markers.push(marker);
+    this.markups = this.markups.slice(0, this.markups.length-closeCount);
   }
 }

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -11,5 +11,9 @@ export default {
     });
 
     return post;
+  },
+
+  parseSection(element) {
+    return SectionParser.parse(element);
   }
 };

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -1,0 +1,15 @@
+import Post from 'content-kit-editor/models/post';
+import SectionParser from 'content-kit-editor/parsers/section';
+import { forEach } from 'content-kit-editor/utils/array-utils';
+
+export default {
+  parse(element) {
+    const post = new Post();
+
+    forEach(element.childNodes, child => {
+      post.appendSection(SectionParser.parse(child));
+    });
+
+    return post;
+  }
+};

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -12,6 +12,11 @@ import { MARKUP_TYPES } from 'content-kit-editor/models/marker';
 import { getAttributes } from 'content-kit-editor/utils/dom-utils';
 import { forEach } from 'content-kit-editor/utils/array-utils';
 
+/**
+ * parses an element into a section, ignoring any non-markup
+ * elements contained within
+ * @return {Section}
+ */
 export default {
   parse(element) {
     if (!this.isSectionElement(element)) {

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -4,12 +4,12 @@ const ELEMENT_NODE = 1;
 import MarkupSection from 'content-kit-editor/models/markup-section';
 import {
   DEFAULT_TAG_NAME,
-  SECTION_TAG_NAMES
-} from 'content-kit-editor/models/section';
+  VALID_MARKUP_SECTION_TAGNAMES
+} from 'content-kit-editor/models/markup-section';
 
 import Marker from 'content-kit-editor/models/marker';
 import Markup from 'content-kit-editor/models/markup';
-import { MARKUP_TAG_NAMES } from 'content-kit-editor/models/marker';
+import { VALID_MARKUP_TAGNAMES } from 'content-kit-editor/models/markup';
 import { getAttributes } from 'content-kit-editor/utils/dom-utils';
 import { forEach } from 'content-kit-editor/utils/array-utils';
 
@@ -93,19 +93,19 @@ export default {
 
   isSectionElement(element) {
     return element.nodeType === ELEMENT_NODE &&
-      SECTION_TAG_NAMES.indexOf(element.tagName.toLowerCase()) !== -1;
+      VALID_MARKUP_SECTION_TAGNAMES.indexOf(element.tagName.toLowerCase()) !== -1;
   },
 
   markupFromElement(element) {
     const tagName = element.tagName.toLowerCase();
-    if (MARKUP_TAG_NAMES.indexOf(tagName) === -1) { return null; }
+    if (VALID_MARKUP_TAGNAMES.indexOf(tagName) === -1) { return null; }
 
     return new Markup(tagName, getAttributes(element));
   },
 
   sectionTagNameFromElement(element) {
     let tagName = element.tagName.toLowerCase();
-    if (SECTION_TAG_NAMES.indexOf(tagName) === -1) { tagName = DEFAULT_TAG_NAME; }
+    if (VALID_MARKUP_SECTION_TAGNAMES.indexOf(tagName) === -1) { tagName = DEFAULT_TAG_NAME; }
     return tagName;
   }
 };

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -1,0 +1,125 @@
+const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+import Section from 'content-kit-editor/models/section';
+import {
+  DEFAULT_TYPE,
+  SECTION_TYPES
+} from 'content-kit-editor/models/section';
+
+import Marker from 'content-kit-editor/models/marker';
+import { MARKUP_TYPES } from 'content-kit-editor/models/marker';
+
+export default {
+  parse(element) {
+    if (!this.isSectionElement(element)) {
+      element = this.wrapInSectionElement(element);
+    }
+
+    const type = this.typeFromTagName(element.tagName);
+    const section = new Section(type);
+    const state = {section, markups:[], text:''};
+
+    this.toArray(element.childNodes).forEach(el => {
+      this.parseNode(el, state);
+    });
+
+    // close a trailing text nodes if it exists
+    if (state.text.length) {
+      let marker = new Marker(state.text, state.markups);
+      state.section.appendMarker(marker);
+    }
+
+    return section;
+  },
+
+  wrapInSectionElement(element) {
+    const parent = document.createElement(DEFAULT_TYPE);
+    parent.appendChild(element);
+    return parent;
+  },
+
+  parseNode(node, state={text:'', markups:[], section:new Section()}) {
+    switch (node.nodeType) {
+      case TEXT_NODE:
+        this.parseTextNode(node, state);
+        break;
+      case ELEMENT_NODE:
+        this.parseElementNode(node, state);
+        break;
+      default:
+        throw new Error(`parseNode got unexpected element type ${node.nodeType} ` + node);
+    }
+  },
+
+  parseElementNode(element, state) {
+    const markup = this.markupFromElement(element);
+    if (markup) {
+      if (state.text.length) {
+        // close previous text marker
+        let marker = new Marker(state.text, state.markups);
+        state.section.appendMarker(marker);
+        state.text = '';
+      }
+
+      state.markups.push(markup);
+    }
+
+    this.toArray(element.childNodes).forEach(node => {
+      this.parseNode(node, state);
+    });
+
+    if (markup) {
+      let marker = new Marker(state.text, state.markups);
+      state.section.appendMarker(marker);
+      state.markups.pop();
+      state.text = '';
+    }
+  },
+
+  parseTextNode(textNode, state) {
+    state.text += textNode.textContent;
+  },
+
+  isSectionElement(element) {
+    return SECTION_TYPES.indexOf(element.tagName) !== -1;
+  },
+
+  markupFromElement(element) {
+    const tagName = element.tagName.toLowerCase();
+    if (MARKUP_TYPES.indexOf(tagName) === -1) { return null; }
+
+    return {
+      type: tagName,
+      attributes: this.attributesToObject(element.attributes)
+    };
+  },
+
+  // convert a NamedNodeMap (`element.attributes`) to a real object with
+  // key-value pairs
+  attributesToObject(attributes=[]) {
+    let result = {};
+
+    for (let i=0; i<attributes.length; i++) {
+      let {name, value} = attributes[i];
+      result[name] = value;
+    }
+
+    return result;
+  },
+
+  toArray(nodeList) {
+    let arr = [];
+    for (let i=0; i<nodeList.length; i++) {
+      arr.push(nodeList[i]);
+    }
+
+    return arr;
+  },
+
+  typeFromTagName(tagName) {
+    let type = tagName.toLowerCase();
+    if (SECTION_TYPES.indexOf(tagName) === -1) { type = DEFAULT_TYPE; }
+    return type;
+  }
+};

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -8,7 +8,7 @@ import {
 } from 'content-kit-editor/models/section';
 
 import Marker from 'content-kit-editor/models/marker';
-import { MARKUP_TYPES } from 'content-kit-editor/models/marker';
+import { MARKUP_TAG_NAMES } from 'content-kit-editor/models/marker';
 import { getAttributes } from 'content-kit-editor/utils/dom-utils';
 import { forEach } from 'content-kit-editor/utils/array-utils';
 
@@ -97,10 +97,10 @@ export default {
 
   markupFromElement(element) {
     const tagName = element.tagName.toLowerCase();
-    if (MARKUP_TYPES.indexOf(tagName) === -1) { return null; }
+    if (MARKUP_TAG_NAMES.indexOf(tagName) === -1) { return null; }
 
     return {
-      type: tagName,
+      tagName: tagName,
       attributes: getAttributes(element)
     };
   },

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -8,6 +8,7 @@ import {
 } from 'content-kit-editor/models/section';
 
 import Marker from 'content-kit-editor/models/marker';
+import Markup from 'content-kit-editor/models/markup';
 import { MARKUP_TAG_NAMES } from 'content-kit-editor/models/marker';
 import { getAttributes } from 'content-kit-editor/utils/dom-utils';
 import { forEach } from 'content-kit-editor/utils/array-utils';
@@ -99,10 +100,7 @@ export default {
     const tagName = element.tagName.toLowerCase();
     if (MARKUP_TAG_NAMES.indexOf(tagName) === -1) { return null; }
 
-    return {
-      tagName: tagName,
-      attributes: getAttributes(element)
-    };
+    return new Markup(tagName, getAttributes(element));
   },
 
   sectionTagNameFromElement(element) {

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -3,8 +3,8 @@ const ELEMENT_NODE = 1;
 
 import Section from 'content-kit-editor/models/section';
 import {
-  DEFAULT_TYPE,
-  SECTION_TYPES
+  DEFAULT_TAG_NAME,
+  SECTION_TAG_NAMES
 } from 'content-kit-editor/models/section';
 
 import Marker from 'content-kit-editor/models/marker';
@@ -16,8 +16,8 @@ export default {
       element = this.wrapInSectionElement(element);
     }
 
-    const type = this.typeFromTagName(element.tagName);
-    const section = new Section(type);
+    const tagName = this.tagNameFromElement(element);
+    const section = new Section(tagName);
     const state = {section, markups:[], text:''};
 
     this.toArray(element.childNodes).forEach(el => {
@@ -34,7 +34,7 @@ export default {
   },
 
   wrapInSectionElement(element) {
-    const parent = document.createElement(DEFAULT_TYPE);
+    const parent = document.createElement(DEFAULT_TAG_NAME);
     parent.appendChild(element);
     return parent;
   },
@@ -82,7 +82,7 @@ export default {
   },
 
   isSectionElement(element) {
-    return SECTION_TYPES.indexOf(element.tagName) !== -1;
+    return SECTION_TAG_NAMES.indexOf(element.tagName) !== -1;
   },
 
   markupFromElement(element) {
@@ -117,9 +117,9 @@ export default {
     return arr;
   },
 
-  typeFromTagName(tagName) {
-    let type = tagName.toLowerCase();
-    if (SECTION_TYPES.indexOf(tagName) === -1) { type = DEFAULT_TYPE; }
-    return type;
+  tagNameFromElement(element) {
+    let tagName = element.tagName.toLowerCase();
+    if (SECTION_TAG_NAMES.indexOf(tagName) === -1) { tagName = DEFAULT_TAG_NAME; }
+    return tagName;
   }
 };

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -1,7 +1,7 @@
 const TEXT_NODE = 3;
 const ELEMENT_NODE = 1;
 
-import Section from 'content-kit-editor/models/section';
+import MarkupSection from 'content-kit-editor/models/markup-section';
 import {
   DEFAULT_TAG_NAME,
   SECTION_TAG_NAMES
@@ -25,7 +25,7 @@ export default {
     }
 
     const tagName = this.sectionTagNameFromElement(element);
-    const section = new Section(tagName);
+    const section = new MarkupSection(tagName);
     const state = {section, markups:[], text:''};
 
     forEach(element.childNodes, (el) => {

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -77,6 +77,10 @@ class Visitor {
     }
   } 
 
+  section(renderNode, section) {
+    this.markupSection(renderNode, section);
+  }
+
   imageSection(renderNode, section) {
     if (renderNode.element) {
       if (renderNode.element.src !== section.src) {

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -2,7 +2,8 @@ import RenderNode from "content-kit-editor/models/render-node";
 import CardNode from "content-kit-editor/models/card-node";
 import { detect } from 'content-kit-editor/utils/array-utils';
 import { POST_TYPE } from "../models/post";
-import { MARKUP_SECTION_TYPE } from "../models/section";
+import { MARKUP_SECTION_TYPE } from "../models/markup-section";
+import { IMAGE_SECTION_TYPE } from "../models/image";
 
 function createElementFromMarkerType(doc, markerType) {
   var element = doc.createElement(markerType.tagName);
@@ -23,7 +24,7 @@ function renderMarkupSection(doc, section, markers) {
   var openedElement;
   for (i=0, l=markers.length;i<l;i++) {
     marker = markers[i];
-    openTypes = marker.open;
+    openTypes = marker.markups;
     closeTypes = marker.close;
     text = marker.value;
 
@@ -77,13 +78,9 @@ class Visitor {
       }
       renderNode.element = element;
     }
-  } 
-
-  section(renderNode, section) {
-    this.markupSection(renderNode, section);
   }
 
-  imageSection(renderNode, section) {
+  [IMAGE_SECTION_TYPE](renderNode, section) {
     if (renderNode.element) {
       if (renderNode.element.src !== section.src) {
         renderNode.element.src = section.src;
@@ -137,7 +134,7 @@ let destroyHooks = {
       renderNode.element.parentNode.removeChild(renderNode.element);
     }
   },
-  imageSection(renderNode, section) {
+  [IMAGE_SECTION_TYPE](renderNode, section) {
     let post = renderNode.parentNode.postNode;
     post.removeSection(section);
     renderNode.element.parentNode.removeChild(renderNode.element);

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -1,6 +1,8 @@
 import RenderNode from "content-kit-editor/models/render-node";
 import CardNode from "content-kit-editor/models/card-node";
 import { detect } from 'content-kit-editor/utils/array-utils';
+import { POST_TYPE } from "../models/post";
+import { MARKUP_SECTION_TYPE } from "../models/section";
 
 function createElementFromMarkerType(doc, markerType) {
   var element = doc.createElement(markerType.tagName);
@@ -52,7 +54,7 @@ class Visitor {
     this.options = options;
   }
 
-  post(renderNode, post, visit) {
+  [POST_TYPE](renderNode, post, visit) {
     if (!renderNode.element) {
       let element = document.createElement('div');
       renderNode.element = element;
@@ -60,7 +62,7 @@ class Visitor {
     visit(renderNode, post.sections);
   }
 
-  markupSection(renderNode, section) {
+  [MARKUP_SECTION_TYPE](renderNode, section) {
     if (!renderNode.element) {
       let element = renderMarkupSection(window.document, section, section.markers);
       if (renderNode.previousSibling) {
@@ -123,10 +125,10 @@ class Visitor {
 }
 
 let destroyHooks = {
-  post(/*renderNode, post*/) {
+  [POST_TYPE](/*renderNode, post*/) {
     throw new Error('post destruction is not supported by the renderer');
   },
-  markupSection(renderNode, section) {
+  [MARKUP_SECTION_TYPE](renderNode, section) {
     let post = renderNode.parentNode.postNode;
     post.removeSection(section);
     // Some formatting commands remove the element from the DOM during

--- a/src/js/renderers/mobiledoc.js
+++ b/src/js/renderers/mobiledoc.js
@@ -1,15 +1,13 @@
 import {visit, visitArray, compile} from "../utils/compiler";
+import { POST_TYPE } from "../models/post";
+import { SECTION_TYPE } from "../models/section";
 
 let visitor = {
-  post(node, opcodes) {
+  [POST_TYPE](node, opcodes) {
     opcodes.push(['openPost']);
     visitArray(visitor, node.sections, opcodes);
   },
-  section(node, opcodes) {
-    opcodes.push(['openMarkupSection', node.tagName]);
-    visitArray(visitor, node.markers, opcodes);
-  },
-  markupSection(node, opcodes) {
+  [SECTION_TYPE](node, opcodes) {
     opcodes.push(['openMarkupSection', node.tagName]);
     visitArray(visitor, node.markers, opcodes);
   },

--- a/src/js/renderers/mobiledoc.js
+++ b/src/js/renderers/mobiledoc.js
@@ -5,6 +5,10 @@ let visitor = {
     opcodes.push(['openPost']);
     visitArray(visitor, node.sections, opcodes);
   },
+  section(node, opcodes) {
+    opcodes.push(['openMarkupSection', node.tagName]);
+    visitArray(visitor, node.markers, opcodes);
+  },
   markupSection(node, opcodes) {
     opcodes.push(['openMarkupSection', node.tagName]);
     visitArray(visitor, node.markers, opcodes);

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -6,6 +6,17 @@ function detect(array, callback) {
   }
 }
 
+/**
+ * Useful for array-like things that aren't
+ * actually arrays, like NodeList
+ */
+function forEach(enumerable, callback) {
+  for (let i=0; i<enumerable.length; i++) {
+    callback(enumerable[i]);
+  }
+}
+
 export {
-  detect
+  detect,
+  forEach
 };

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -38,9 +38,27 @@ function forEachChildNode(element, callback) {
   }
 }
 
+/**
+ * converts the element's NamedNodeMap of attrs into
+ * an object with key-value pairs
+ */
+function getAttributes(element) {
+  let result = {};
+  if (element.hasAttributes()) {
+    let attributes = element.attributes;
+
+    for (let i=0; i<attributes.length; i++) {
+      let {name, value} = attributes[i];
+      result[name] = value;
+    }
+  }
+  return result;
+}
+
 export {
   detectParentNode,
   containsNode,
   clearChildNodes,
-  forEachChildNode
+  forEachChildNode,
+  getAttributes
 };

--- a/src/js/utils/post-builder.js
+++ b/src/js/utils/post-builder.js
@@ -1,19 +1,13 @@
 import Post from "../models/post";
+import MarkupSection from "../models/markup-section";
 import ImageSection from "../models/image";
 
 var builder = {
   generatePost() {
     return new Post();
   },
-  generateSection(tagName, attributes, isGenerated) {
-    var section = {
-      type: 'markupSection',
-      tagName: tagName,
-      markers: []
-    };
-    if (attributes && attributes.length) {
-      section.attributes = attributes;
-    }
+  generateMarkupSection(tagName, attributes, isGenerated) {
+    let section = new MarkupSection(tagName);
     if (isGenerated) {
       section.isGenerated = !!isGenerated;
     }

--- a/src/js/utils/post-builder.js
+++ b/src/js/utils/post-builder.js
@@ -1,6 +1,8 @@
 import Post from "../models/post";
 import MarkupSection from "../models/markup-section";
 import ImageSection from "../models/image";
+import Marker from "../models/marker";
+import Markup from "../models/markup";
 
 var builder = {
   generatePost() {
@@ -24,32 +26,17 @@ var builder = {
     const type = 'card';
     return { name, payload, type };
   },
-  // open: Array
-  // close: Integer
-  // value: String
-  generateMarker: function(open, close, value) {
-    return {
-      type: 'marker',
-      open: open,
-      close: close,
-      value: value
-    };
+  generateMarker: function(markers, value) {
+    return new Marker(value, markers);
   },
-  generateMarkerType: function(tagName, attributes) {
+  generateMarkup: function(tagName, attributes) {
     if (attributes) {
       // FIXME: This could also be cached
-      return {
-        type: 'markerType',
-        tagName: tagName,
-        attributes: attributes
-      };
+      return new Markup(tagName, attributes);
     }
     var markerType = this._markerTypeCache[tagName];
     if (!markerType) {
-      this._markerTypeCache[tagName] = markerType = {
-        type: 'markerType',
-        tagName: tagName
-      };
+      this._markerTypeCache[tagName] = markerType = new Markup(tagName);
     }
     return markerType;
   }

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -96,10 +96,28 @@ function triggerKeyEvent(node, eventType, keyCode=KEY_CODES.ENTER) {
   node.dispatchEvent(oEvent);
 }
 
+function makeTextNode(text) {
+  return document.createTextNode(text);
+}
+
+/**
+ * to create a text node use tagName='text', {value:'the text'}
+ */
+function makeDOM(tagName, attributes={}, children=[]) {
+  if (tagName === 'text') { return makeTextNode(attributes.value); }
+
+  let el = document.createElement(tagName);
+  Object.keys(attributes).forEach(k => el.setAttribute(k, attributes[k]));
+  children.forEach(child => el.appendChild(makeDOM(...child)));
+
+  return el;
+}
+
 export default {
   moveCursorTo,
   selectText,
   clearSelection,
   triggerEvent,
-  triggerKeyEvent
+  triggerKeyEvent,
+  makeDOM
 };

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -96,21 +96,29 @@ function triggerKeyEvent(node, eventType, keyCode=KEY_CODES.ENTER) {
   node.dispatchEvent(oEvent);
 }
 
-function makeTextNode(text) {
-  return document.createTextNode(text);
+function _buildDOM(tagName, attributes={}, children=[]) {
+  const el = document.createElement(tagName);
+  Object.keys(attributes).forEach(k => el.setAttribute(k, attributes[k]));
+  children.forEach(child => el.appendChild(child));
+  return el;
 }
 
+_buildDOM.text = (string) => {
+  return document.createTextNode(string);
+};
+
 /**
- * to create a text node use tagName='text', {value:'the text'}
+ * Usage:
+ * makeDOM(t =>
+ *   t('div', attributes={}, children=[
+ *     t('b', {}, [
+ *       t.text('I am a bold text node')
+ *     ])
+ *   ])
+ * );
  */
-function makeDOM(tagName, attributes={}, children=[]) {
-  if (tagName === 'text') { return makeTextNode(attributes.value); }
-
-  let el = document.createElement(tagName);
-  Object.keys(attributes).forEach(k => el.setAttribute(k, attributes[k]));
-  children.forEach(child => el.appendChild(makeDOM(...child)));
-
-  return el;
+function makeDOM(tree) {
+  return tree(_buildDOM);
 }
 
 export default {

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -1,6 +1,7 @@
 const {module, test} = QUnit;
 
 import Marker from 'content-kit-editor/models/marker';
+import Markup from 'content-kit-editor/models/markup';
 
 module('Unit: Marker');
 
@@ -28,22 +29,22 @@ test('a marker can truncated to an offset', (assert) => {
 
 test('a marker can have a markup applied to it', (assert) => {
   const m1 = new Marker('hi there!');
-  m1.addMarkup('b');
+  m1.addMarkup(new Markup('b'));
 
   assert.ok(m1.hasMarkup('b'));
 });
 
 test('a marker cannot have the same markup tagName applied twice', (assert) => {
   const m1 = new Marker('hi there!');
-  m1.addMarkup('b');
-  m1.addMarkup('b');
+  m1.addMarkup(new Markup('b'));
+  m1.addMarkup(new Markup('b'));
 
   assert.equal(m1.markups.length, 1, 'markup only applied once');
 });
 
 test('a marker can have a complex markup applied to it', (assert) => {
   const m1 = new Marker('hi there!');
-  const markup = {tagName: 'a', attributes:{href:'blah'}};
+  const markup = new Markup('a', {href:'blah'});
   m1.addMarkup(markup);
 
   assert.ok(m1.hasMarkup('a'));
@@ -52,8 +53,8 @@ test('a marker can have a complex markup applied to it', (assert) => {
 
 test('a marker cannot have the same complex markup tagName applied twice, even with different attributes', (assert) => {
   const m1 = new Marker('hi there!');
-  const markup1 = {tagName: 'a', attributes:{href:'blah'}};
-  const markup2 = {tagName: 'a', attributes:{href:'blah2'}};
+  const markup1 = new Markup('a', {href:'blah'});
+  const markup2 = new Markup('a', {href:'blah2'});
   m1.addMarkup(markup1);
   m1.addMarkup(markup2);
 
@@ -64,9 +65,9 @@ test('a marker cannot have the same complex markup tagName applied twice, even w
 
 test('a marker can be joined to another', (assert) => {
   const m1 = new Marker('hi');
-  m1.addMarkup('b');
+  m1.addMarkup(new Markup('b'));
   const m2 = new Marker(' there!');
-  m2.addMarkup('i');
+  m2.addMarkup(new Markup('i'));
 
   const m3 = m1.join(m2);
   assert.equal(m3.value, 'hi there!');
@@ -76,7 +77,7 @@ test('a marker can be joined to another', (assert) => {
 
 test('a marker can be split into two', (assert) => {
   const m1 = new Marker('hi there!');
-  m1.addMarkup('b');
+  m1.addMarkup(new Markup('b'));
 
   const [_m1, m2] = m1.split(5);
   assert.ok(_m1.hasMarkup('b') && m2.hasMarkup('b'),

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -34,12 +34,12 @@ test('a marker can have a markup applied to it', (assert) => {
   assert.ok(m1.hasMarkup('b'));
 });
 
-test('a marker cannot have the same markup tagName applied twice', (assert) => {
+test('a marker can have the same markup tagName applied twice', (assert) => {
   const m1 = new Marker('hi there!');
   m1.addMarkup(new Markup('b'));
   m1.addMarkup(new Markup('b'));
 
-  assert.equal(m1.markups.length, 1, 'markup only applied once');
+  assert.equal(m1.markups.length, 2, 'markup only applied once');
 });
 
 test('a marker can have a complex markup applied to it', (assert) => {
@@ -51,14 +51,14 @@ test('a marker can have a complex markup applied to it', (assert) => {
   assert.equal(m1.getMarkup('a').attributes.href, 'blah');
 });
 
-test('a marker cannot have the same complex markup tagName applied twice, even with different attributes', (assert) => {
+test('a marker can have the same complex markup tagName applied twice, even with different attributes', (assert) => {
   const m1 = new Marker('hi there!');
   const markup1 = new Markup('a', {href:'blah'});
   const markup2 = new Markup('a', {href:'blah2'});
   m1.addMarkup(markup1);
   m1.addMarkup(markup2);
 
-  assert.equal(m1.markups.length, 1, 'only one markup');
+  assert.equal(m1.markups.length, 2, 'only one markup');
   assert.equal(m1.getMarkup('a').attributes.href, 'blah',
                'first markup is applied');
 });

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -1,0 +1,87 @@
+const {module, test} = QUnit;
+
+import Marker from 'content-kit-editor/models/marker';
+
+module('Unit: Marker');
+
+test('Marker exists', (assert) => {
+  assert.ok(Marker);
+});
+
+test('a marker can truncated from an offset', (assert) => {
+  const m1 = new Marker('hi there!');
+
+  const offset = 5;
+  m1.truncateFrom(offset);
+
+  assert.equal(m1.value, 'hi th');
+});
+
+test('a marker can truncated to an offset', (assert) => {
+  const m1 = new Marker('hi there!');
+
+  const offset = 5;
+  m1.truncateTo(offset);
+
+  assert.equal(m1.value, 'ere!');
+});
+
+test('a marker can have a markup applied to it', (assert) => {
+  const m1 = new Marker('hi there!');
+  m1.addMarkup('b');
+
+  assert.ok(m1.hasMarkup('b'));
+});
+
+test('a marker cannot have the same markup type applied twice', (assert) => {
+  const m1 = new Marker('hi there!');
+  m1.addMarkup('b');
+  m1.addMarkup('b');
+
+  assert.equal(m1.markups.length, 1, 'markup only applied once');
+});
+
+test('a marker can have a complex markup applied to it', (assert) => {
+  const m1 = new Marker('hi there!');
+  const markup = {type: 'a', attributes:{href:'blah'}};
+  m1.addMarkup(markup);
+
+  assert.ok(m1.hasMarkup('a'));
+  assert.equal(m1.getMarkup('a').attributes.href, 'blah');
+});
+
+test('a marker cannot have the same complex markup type applied twice, even with different attributes', (assert) => {
+  const m1 = new Marker('hi there!');
+  const markup1 = {type: 'a', attributes:{href:'blah'}};
+  const markup2 = {type: 'a', attributes:{href:'blah2'}};
+  m1.addMarkup(markup1);
+  m1.addMarkup(markup2);
+
+  assert.equal(m1.markups.length, 1, 'only one markup');
+  assert.equal(m1.getMarkup('a').attributes.href, 'blah',
+               'first markup is applied');
+});
+
+test('a marker can be joined to another', (assert) => {
+  const m1 = new Marker('hi');
+  m1.addMarkup('b');
+  const m2 = new Marker(' there!');
+  m2.addMarkup('i');
+
+  const m3 = m1.join(m2);
+  assert.equal(m3.value, 'hi there!');
+  assert.ok(m3.hasMarkup('b'));
+  assert.ok(m3.hasMarkup('i'));
+});
+
+test('a marker can be split into two', (assert) => {
+  const m1 = new Marker('hi there!');
+  m1.addMarkup('b');
+
+  const [_m1, m2] = m1.split(5);
+  assert.ok(_m1.hasMarkup('b') && m2.hasMarkup('b'),
+            'both markers get the markup');
+
+  assert.equal(_m1.value, 'hi th');
+  assert.equal(m2.value, 'ere!');
+});

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -33,7 +33,7 @@ test('a marker can have a markup applied to it', (assert) => {
   assert.ok(m1.hasMarkup('b'));
 });
 
-test('a marker cannot have the same markup type applied twice', (assert) => {
+test('a marker cannot have the same markup tagName applied twice', (assert) => {
   const m1 = new Marker('hi there!');
   m1.addMarkup('b');
   m1.addMarkup('b');
@@ -43,17 +43,17 @@ test('a marker cannot have the same markup type applied twice', (assert) => {
 
 test('a marker can have a complex markup applied to it', (assert) => {
   const m1 = new Marker('hi there!');
-  const markup = {type: 'a', attributes:{href:'blah'}};
+  const markup = {tagName: 'a', attributes:{href:'blah'}};
   m1.addMarkup(markup);
 
   assert.ok(m1.hasMarkup('a'));
   assert.equal(m1.getMarkup('a').attributes.href, 'blah');
 });
 
-test('a marker cannot have the same complex markup type applied twice, even with different attributes', (assert) => {
+test('a marker cannot have the same complex markup tagName applied twice, even with different attributes', (assert) => {
   const m1 = new Marker('hi there!');
-  const markup1 = {type: 'a', attributes:{href:'blah'}};
-  const markup2 = {type: 'a', attributes:{href:'blah2'}};
+  const markup1 = {tagName: 'a', attributes:{href:'blah'}};
+  const markup2 = {tagName: 'a', attributes:{href:'blah2'}};
   m1.addMarkup(markup1);
   m1.addMarkup(markup2);
 

--- a/tests/unit/models/section-test.js
+++ b/tests/unit/models/section-test.js
@@ -1,6 +1,6 @@
 const {module, test} = QUnit;
 
-import Section from 'content-kit-editor/models/section';
+import Section from 'content-kit-editor/models/markup-section';
 import Marker from 'content-kit-editor/models/marker';
 import Markup from 'content-kit-editor/models/markup';
 

--- a/tests/unit/models/section-test.js
+++ b/tests/unit/models/section-test.js
@@ -1,0 +1,114 @@
+const {module, test} = QUnit;
+
+import Section from 'content-kit-editor/models/section';
+import Marker from 'content-kit-editor/models/marker';
+
+module('Unit: Section');
+
+test('Section exists', (assert) => {
+  assert.ok(Section);
+});
+
+test('a section can append a marker', (assert) => {
+  const s1 = new Section();
+  const m1 = new Marker('hello');
+
+  s1.appendMarker(m1);
+  assert.equal(s1.markers.length, 1);
+});
+
+test('#markerContaining finds the marker at the given offset when 1 marker', (assert) => {
+  const m = new Marker('hi there!');
+  const s = new Section('h2',[m]);
+
+  for (let i=0; i<m.length; i++) {
+    assert.equal(s.markerContaining(i), m, `finds marker at offset ${i}`);
+  }
+});
+
+test('#markerContaining finds the marker at the given offset when 2 markers', (assert) => {
+  const m1 = new Marker('hi ');
+  const m2 = new Marker('there!');
+  const s = new Section('h2',[m1,m2]);
+
+  assert.equal(s.markerContaining(0), m1,
+               'first marker is always found at offset 0');
+  assert.equal(s.markerContaining(m1.length + m2.length), m2,
+               'last marker is always found at offset === length');
+  assert.equal(s.markerContaining(m1.length + m2.length + 1), m2,
+               'last marker is always found at offset > length');
+
+  for (let i=1; i<m1.length; i++) {
+    assert.equal(s.markerContaining(i), m1, `finds marker 1 at offset ${i}`);
+  }
+  assert.equal(s.markerContaining(m1.length),
+               m1,
+               `markers are right-inclusive`);
+
+  for (let i=m1.length+1; i<(m1.length+m2.length); i++) {
+    assert.equal(s.markerContaining(i), m2, `finds marker 2 at offset ${i}`);
+  }
+});
+
+test('#markerContaining finds the marker at the given offset when multiple markers', (assert) => {
+  const m1 = new Marker('hi ');
+  const m2 = new Marker('there!');
+  const m3 = new Marker(' and more');
+  const markerLength = [m1,m2,m3].reduce((prev, cur) => prev + cur.length, 0);
+  const s = new Section('h2',[m1,m2,m3]);
+
+  assert.equal(s.markerContaining(0), m1,
+               'first marker is always found at offset 0');
+  assert.equal(s.markerContaining(markerLength), m3,
+               'last marker is always found at offset === length');
+  assert.equal(s.markerContaining(markerLength + 1), m3,
+               'last marker is always found at offset > length');
+
+  for (let i=1; i<m1.length; i++) {
+    assert.equal(s.markerContaining(i), m1, `finds marker 1 at offset ${i}`);
+  }
+  assert.equal(s.markerContaining(m1.length), m1, `markers are right-inclusive`);
+  for (let i=m1.length+1; i<(m1.length+m2.length); i++) {
+    assert.equal(s.markerContaining(i), m2, `finds marker 2 at offset ${i}`);
+  }
+  assert.equal(s.markerContaining(m1.length+m2.length), m2, `markers are right-inclusive v2`);
+  for (let i=m1.length+m2.length+1; i<markerLength; i++) {
+    assert.equal(s.markerContaining(i), m3, `finds marker 3 at offset ${i}`);
+  }
+});
+
+test('a section can be split, splitting its markers', (assert) => {
+  const m = new Marker('hi there!', ['b']);
+  const s = new Section('p', [m]);
+
+  const [s1, s2] = s.split(5);
+  assert.equal(s1.markers.length, 1, 's1 has marker');
+  assert.equal(s2.markers.length, 1, 's2 has marker');
+
+  assert.ok(s1.markers[0].hasMarkup('b'));
+  assert.equal(s1.markers[0].value, 'hi th');
+
+  assert.ok(s2.markers[0].hasMarkup('b'));
+  assert.equal(s2.markers[0].value, 'ere!');
+});
+
+test('a section can be split, splitting its markers when multiple markers', (assert) => {
+  const m1 = new Marker('hi ');
+  const m2 = new Marker('there!');
+  const s = new Section('h2', [m1,m2]);
+
+  const [s1, s2] = s.split(5);
+  assert.equal(s1.markers.length, 2, 's1 has 2 markers');
+  assert.equal(s2.markers.length, 1, 's2 has 1 marker');
+
+  assert.equal(s1.markers[0].value, 'hi ');
+  assert.equal(s1.markers[1].value, 'th');
+  assert.equal(s2.markers[0].value, 'ere!');
+});
+
+// test: a section can parse dom
+
+// test: a section can clear a range:
+//   * truncating the markers on the boundaries
+//   * removing the intermediate markers
+//   * connecting (but not joining) the truncated boundary markers

--- a/tests/unit/models/section-test.js
+++ b/tests/unit/models/section-test.js
@@ -2,6 +2,7 @@ const {module, test} = QUnit;
 
 import Section from 'content-kit-editor/models/section';
 import Marker from 'content-kit-editor/models/marker';
+import Markup from 'content-kit-editor/models/markup';
 
 module('Unit: Section');
 
@@ -78,7 +79,7 @@ test('#markerContaining finds the marker at the given offset when multiple marke
 });
 
 test('a section can be split, splitting its markers', (assert) => {
-  const m = new Marker('hi there!', ['b']);
+  const m = new Marker('hi there!', [new Markup('b')]);
   const s = new Section('p', [m]);
 
   const [s1, s2] = s.split(5);

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -32,10 +32,10 @@ test('parse empty content', (assert) => {
 test('blank textnodes are ignored', (assert) => {
   let post = parser.parse(buildDOM('<p>first line</p>\n<p>second line</p>'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'first line'));
   expectedPost.appendSection(expectedFirst);
-  let expectedSecond = builder.generateSection('P');
+  let expectedSecond = builder.generateMarkupSection('P');
   expectedSecond.markers.push(builder.generateMarker([], 0, 'second line'));
   expectedPost.appendSection(expectedSecond);
 
@@ -45,10 +45,10 @@ test('blank textnodes are ignored', (assert) => {
 test('textnode adjacent to p tag becomes section', (assert) => {
   const post = parser.parse(buildDOM('<p>first line</p>second line'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'first line'));
   expectedPost.appendSection(expectedFirst);
-  let expectedSecond = builder.generateSection('P', {}, true);
+  let expectedSecond = builder.generateMarkupSection('P', {}, true);
   expectedSecond.markers.push(builder.generateMarker([], 0, 'second line'));
   expectedPost.appendSection(expectedSecond);
 
@@ -58,7 +58,7 @@ test('textnode adjacent to p tag becomes section', (assert) => {
 test('p tag (section markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('<p>text</p>'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'text'));
   expectedPost.appendSection(expectedFirst);
 
@@ -68,7 +68,7 @@ test('p tag (section markup) should create a block', (assert) => {
 test('strong tag (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('<strong>text</strong>'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('STRONG')
   ], 1, 'text'));
@@ -80,7 +80,7 @@ test('strong tag (stray markup) without a block should create a block', (assert)
 test('strong tag with inner em (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('<strong><em>stray</em> markup tags</strong>.'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('STRONG'),
     builder.generateMarkerType('EM')
@@ -95,7 +95,7 @@ test('strong tag with inner em (stray markup) without a block should create a bl
 test('stray text (stray markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('text'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([], 0, 'text'));
   expectedPost.appendSection(expectedFirst);
 
@@ -105,7 +105,7 @@ test('stray text (stray markup) should create a block', (assert) => {
 test('text node, strong tag, text node (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('start <strong>bold</strong> end'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([], 0, 'start '));
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('STRONG')
@@ -119,7 +119,7 @@ test('text node, strong tag, text node (stray markup) without a block should cre
 test('italic tag (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('<em>text</em>'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('EM')
   ], 1, 'text'));
@@ -131,7 +131,7 @@ test('italic tag (stray markup) without a block should create a block', (assert)
 test('u tag (stray markup) without a block should strip U and create a block', (assert) => {
   const post = parser.parse(buildDOM('<u>text</u>'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([], 0, 'text'));
   expectedPost.appendSection(expectedFirst);
 
@@ -142,7 +142,7 @@ test('a tag (stray markup) without a block should create a block', (assert) => {
   var url = "http://test.com";
   const post = parser.parse(buildDOM('<a href="'+url+'">text</a>'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('A', ['href', url])
   ], 1, 'text'));
@@ -155,7 +155,7 @@ test('a tag (stray markup) without a block should create a block', (assert) => {
 test('markup: break', (assert) => {
   const post = parser.parse(buildDOM('line <br/>break'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([], 0, 'line '));
   expectedFirst.markers.push(builder.generateMarker([], 0, 'break'));
   expectedPost.appendSection(expectedFirst);
@@ -167,7 +167,7 @@ test('markup: break', (assert) => {
 test('sub tag (stray markup) without a block should filter SUB and create a block', (assert) => {
   const post = parser.parse(buildDOM('footnote<sub>1</sub>'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([], 0, 'footnote'));
   expectedFirst.markers.push(builder.generateMarker([], 0, '1'));
   expectedPost.appendSection(expectedFirst);
@@ -178,7 +178,7 @@ test('sub tag (stray markup) without a block should filter SUB and create a bloc
 test('sup tag (stray markup) without a block should filter SUP and create a block', (assert) => {
   const post = parser.parse(buildDOM('e=mc<sup>2</sup>'));
 
-  let expectedFirst = builder.generateSection('P', {}, true);
+  let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([], 0, 'e=mc'));
   expectedFirst.markers.push(builder.generateMarker([], 0, '2'));
   expectedPost.appendSection(expectedFirst);
@@ -189,7 +189,7 @@ test('sup tag (stray markup) without a block should filter SUP and create a bloc
 test('list (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('<ul><li>Item 1</li><li>Item 2</li></ul>'));
 
-  let expectedFirst = builder.generateSection('UL');
+  let expectedFirst = builder.generateMarkupSection('UL');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('LI')
   ], 1, 'Item 1'));
@@ -204,7 +204,7 @@ test('list (stray markup) without a block should create a block', (assert) => {
 test('nested tags (section markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('<p><em><strong>Double.</strong></em> <strong><em>Double staggered</em> start.</strong> <strong>Double <em>staggered end.</em></strong> <strong>Double <em>staggered</em> middle.</strong></p>'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('EM'),
     builder.generateMarkerType('STRONG')
@@ -336,7 +336,7 @@ test('attributes', (assert) => {
   const rel = 'nofollow';
   const post = parser.parse(buildDOM(`<p><a href="${href}" rel="${rel}">Link to google.com</a></p>`));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('A', ['href', href, 'rel', rel])
   ], 1, 'Link to google.com'));
@@ -348,7 +348,7 @@ test('attributes', (assert) => {
 test('attributes filters out inline styles and classes', (assert) => {
   const post = parser.parse(buildDOM('<p class="test" style="color:red;"><b style="line-height:11px">test</b></p>'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('B')
   ], 1, 'test'));
@@ -360,7 +360,7 @@ test('attributes filters out inline styles and classes', (assert) => {
 test('blocks: paragraph', (assert) => {
   const post = parser.parse(buildDOM('<p>TEXT</p>'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
@@ -370,7 +370,7 @@ test('blocks: paragraph', (assert) => {
 test('blocks: heading', (assert) => {
   const post = parser.parse(buildDOM('<h2>TEXT</h2>'));
 
-  let expectedFirst = builder.generateSection('H2');
+  let expectedFirst = builder.generateMarkupSection('H2');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
@@ -380,7 +380,7 @@ test('blocks: heading', (assert) => {
 test('blocks: subheading', (assert) => {
   const post = parser.parse(buildDOM('<h3>TEXT</h3>'));
 
-  let expectedFirst = builder.generateSection('H3');
+  let expectedFirst = builder.generateMarkupSection('H3');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
@@ -405,7 +405,7 @@ test('blocks: image', (assert) => {
 test('blocks: quote', (assert) => {
   const post = parser.parse(buildDOM('<blockquote>quote</blockquote>'));
 
-  let expectedFirst = builder.generateSection('BLOCKQUOTE');
+  let expectedFirst = builder.generateMarkupSection('BLOCKQUOTE');
   expectedFirst.markers.push(builder.generateMarker([], 0, 'quote'));
   expectedPost.appendSection(expectedFirst);
 
@@ -415,7 +415,7 @@ test('blocks: quote', (assert) => {
 test('blocks: list', (assert) => {
   const post = parser.parse(buildDOM('<ul><li>Item 1</li> <li>Item 2</li></ul>'));
 
-  let expectedFirst = builder.generateSection('UL');
+  let expectedFirst = builder.generateMarkupSection('UL');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('LI')
   ], 1, 'Item 1'));
@@ -431,7 +431,7 @@ test('blocks: list', (assert) => {
 test('blocks: ordered list', (assert) => {
   const post = parser.parse(buildDOM('<ol><li>Item 1</li> <li>Item 2</li></ol>'));
 
-  let expectedFirst = builder.generateSection('OL');
+  let expectedFirst = builder.generateMarkupSection('OL');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('LI')
   ], 1, 'Item 1'));
@@ -497,7 +497,7 @@ test('converts tags to mapped values', (assert) => {
   // FIXME: Should probably be normalizing b to strong etc
   const post = parser.parse(buildDOM('<p><b><i>Converts</i> tags</b>.</p>'));
 
-  let expectedFirst = builder.generateSection('P');
+  let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
     builder.generateMarkerType('B'),
     builder.generateMarkerType('I')

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -33,10 +33,10 @@ test('blank textnodes are ignored', (assert) => {
   let post = parser.parse(buildDOM('<p>first line</p>\n<p>second line</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 'first line'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'first line'));
   expectedPost.appendSection(expectedFirst);
   let expectedSecond = builder.generateMarkupSection('P');
-  expectedSecond.markers.push(builder.generateMarker([], 'second line'));
+  expectedSecond.appendMarker(builder.generateMarker([], 'second line'));
   expectedPost.appendSection(expectedSecond);
 
   assert.deepEqual(post, expectedPost);
@@ -46,10 +46,10 @@ test('textnode adjacent to p tag becomes section', (assert) => {
   const post = parser.parse(buildDOM('<p>first line</p>second line'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 'first line'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'first line'));
   expectedPost.appendSection(expectedFirst);
   let expectedSecond = builder.generateMarkupSection('P', {}, true);
-  expectedSecond.markers.push(builder.generateMarker([], 'second line'));
+  expectedSecond.appendMarker(builder.generateMarker([], 'second line'));
   expectedPost.appendSection(expectedSecond);
 
   assert.deepEqual(post, expectedPost);
@@ -59,7 +59,7 @@ test('p tag (section markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('<p>text</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 'text'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -69,7 +69,7 @@ test('strong tag (stray markup) without a block should create a block', (assert)
   const post = parser.parse(buildDOM('<strong>text</strong>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('STRONG')
   ], 'text'));
   expectedPost.appendSection(expectedFirst);
@@ -82,12 +82,12 @@ test('strong tag with inner em (stray markup) without a block should create a bl
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
   let strong = builder.generateMarkup('STRONG');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     strong,
     builder.generateMarkup('EM')
   ], 'stray'));
-  expectedFirst.markers.push(builder.generateMarker([strong], ' markup tags'));
-  expectedFirst.markers.push(builder.generateMarker([], '.'));
+  expectedFirst.appendMarker(builder.generateMarker([strong], ' markup tags'));
+  expectedFirst.appendMarker(builder.generateMarker([], '.'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -97,7 +97,7 @@ test('stray text (stray markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('text'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 'text'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -107,11 +107,11 @@ test('text node, strong tag, text node (stray markup) without a block should cre
   const post = parser.parse(buildDOM('start <strong>bold</strong> end'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 'start '));
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([], 'start '));
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('STRONG')
   ], 'bold'));
-  expectedFirst.markers.push(builder.generateMarker([], ' end'));
+  expectedFirst.appendMarker(builder.generateMarker([], ' end'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -121,7 +121,7 @@ test('italic tag (stray markup) without a block should create a block', (assert)
   const post = parser.parse(buildDOM('<em>text</em>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('EM')
   ], 'text'));
   expectedPost.appendSection(expectedFirst);
@@ -133,7 +133,7 @@ test('u tag (stray markup) without a block should strip U and create a block', (
   const post = parser.parse(buildDOM('<u>text</u>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 'text'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -144,7 +144,7 @@ test('a tag (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('<a href="'+url+'">text</a>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('A', ['href', url])
   ], 'text'));
   expectedPost.appendSection(expectedFirst);
@@ -157,8 +157,8 @@ test('markup: break', (assert) => {
   const post = parser.parse(buildDOM('line <br/>break'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'line '));
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'break'));
+  expectedFirst.appendMarker(builder.generateMarker([], 0, 'line '));
+  expectedFirst.appendMarker(builder.generateMarker([], 0, 'break'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -169,8 +169,8 @@ test('sub tag (stray markup) without a block should filter SUB and create a bloc
   const post = parser.parse(buildDOM('footnote<sub>1</sub>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 'footnote'));
-  expectedFirst.markers.push(builder.generateMarker([], '1'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'footnote'));
+  expectedFirst.appendMarker(builder.generateMarker([], '1'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -180,8 +180,8 @@ test('sup tag (stray markup) without a block should filter SUP and create a bloc
   const post = parser.parse(buildDOM('e=mc<sup>2</sup>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 'e=mc'));
-  expectedFirst.markers.push(builder.generateMarker([], '2'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'e=mc'));
+  expectedFirst.appendMarker(builder.generateMarker([], '2'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -191,10 +191,10 @@ test('list (stray markup) without a block should create a block', (assert) => {
   const post = parser.parse(buildDOM('<ul><li>Item 1</li><li>Item 2</li></ul>'));
 
   let expectedFirst = builder.generateMarkupSection('UL');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('LI')
   ], 'Item 1'));
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('LI')
   ], 'Item 2'));
   expectedPost.appendSection(expectedFirst);
@@ -206,39 +206,41 @@ test('nested tags (section markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('<p><em><strong>Double.</strong></em> <strong><em>Double staggered</em> start.</strong> <strong>Double <em>staggered end.</em></strong> <strong>Double <em>staggered</em> middle.</strong></p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('EM'),
     builder.generateMarkup('STRONG')
   ], 'Double.'));
-  expectedFirst.markers.push(builder.generateMarker([], ' '));
+  expectedFirst.appendMarker(builder.generateMarker([], ' '));
   let firstStrong = builder.generateMarkup('STRONG');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     firstStrong,
     builder.generateMarkup('EM')
   ], 'Double staggered'));
-  expectedFirst.markers.push(builder.generateMarker([firstStrong], ' start.'));
-  expectedFirst.markers.push(builder.generateMarker([], ' '));
+  expectedFirst.appendMarker(builder.generateMarker([firstStrong], ' start.'));
+  expectedFirst.appendMarker(builder.generateMarker([], ' '));
   let secondStrong = builder.generateMarkup('STRONG');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     secondStrong
   ], 'Double '));
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     secondStrong,
     builder.generateMarkup('EM')
   ], 'staggered end.'));
-  expectedFirst.markers.push(builder.generateMarker([], ' '));
+  expectedFirst.appendMarker(builder.generateMarker([], ' '));
   let thirdStrong = builder.generateMarkup('STRONG');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     thirdStrong
   ], 'Double '));
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     thirdStrong,
     builder.generateMarkup('EM')
   ], 'staggered'));
-  expectedFirst.markers.push(builder.generateMarker([thirdStrong], ' middle.'));
+  expectedFirst.appendMarker(builder.generateMarker([thirdStrong], ' middle.'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
+  let sectionMarkers = post.sections[0].markers;
+  assert.equal(sectionMarkers[2].markups[0], sectionMarkers[3].markups[0]);
 });
 
 /*
@@ -343,7 +345,7 @@ test('attributes', (assert) => {
   const post = parser.parse(buildDOM(`<p><a href="${href}" rel="${rel}">Link to google.com</a></p>`));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('A', ['href', href, 'rel', rel])
   ], 'Link to google.com'));
   expectedPost.appendSection(expectedFirst);
@@ -355,7 +357,7 @@ test('attributes filters out inline styles and classes', (assert) => {
   const post = parser.parse(buildDOM('<p class="test" style="color:red;"><b style="line-height:11px">test</b></p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('B')
   ], 'test'));
   expectedPost.appendSection(expectedFirst);
@@ -367,7 +369,7 @@ test('blocks: paragraph', (assert) => {
   const post = parser.parse(buildDOM('<p>TEXT</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 'TEXT'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -377,7 +379,7 @@ test('blocks: heading', (assert) => {
   const post = parser.parse(buildDOM('<h2>TEXT</h2>'));
 
   let expectedFirst = builder.generateMarkupSection('H2');
-  expectedFirst.markers.push(builder.generateMarker([], 'TEXT'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -387,7 +389,7 @@ test('blocks: subheading', (assert) => {
   const post = parser.parse(buildDOM('<h3>TEXT</h3>'));
 
   let expectedFirst = builder.generateMarkupSection('H3');
-  expectedFirst.markers.push(builder.generateMarker([], 'TEXT'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -412,7 +414,7 @@ test('blocks: quote', (assert) => {
   const post = parser.parse(buildDOM('<blockquote>quote</blockquote>'));
 
   let expectedFirst = builder.generateMarkupSection('BLOCKQUOTE');
-  expectedFirst.markers.push(builder.generateMarker([], 'quote'));
+  expectedFirst.appendMarker(builder.generateMarker([], 'quote'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -422,11 +424,11 @@ test('blocks: list', (assert) => {
   const post = parser.parse(buildDOM('<ul><li>Item 1</li> <li>Item 2</li></ul>'));
 
   let expectedFirst = builder.generateMarkupSection('UL');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('LI')
   ], 'Item 1'));
-  expectedFirst.markers.push(builder.generateMarker([], ' '));
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([], ' '));
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('LI')
   ], 'Item 2'));
   expectedPost.appendSection(expectedFirst);
@@ -438,11 +440,11 @@ test('blocks: ordered list', (assert) => {
   const post = parser.parse(buildDOM('<ol><li>Item 1</li> <li>Item 2</li></ol>'));
 
   let expectedFirst = builder.generateMarkupSection('OL');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('LI')
   ], 'Item 1'));
-  expectedFirst.markers.push(builder.generateMarker([], ' '));
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([], ' '));
+  expectedFirst.appendMarker(builder.generateMarker([
     builder.generateMarkup('LI')
   ], 'Item 2'));
   expectedPost.appendSection(expectedFirst);
@@ -505,12 +507,12 @@ test('converts tags to mapped values', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('P');
   let bold = builder.generateMarkup('B');
-  expectedFirst.markers.push(builder.generateMarker([
+  expectedFirst.appendMarker(builder.generateMarker([
     bold,
     builder.generateMarkup('I')
   ], 'Converts'));
-  expectedFirst.markers.push(builder.generateMarker([bold], ' tags'));
-  expectedFirst.markers.push(builder.generateMarker([], '.'));
+  expectedFirst.appendMarker(builder.generateMarker([bold], ' tags'));
+  expectedFirst.appendMarker(builder.generateMarker([], '.'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -33,10 +33,10 @@ test('blank textnodes are ignored', (assert) => {
   let post = parser.parse(buildDOM('<p>first line</p>\n<p>second line</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'first line'));
+  expectedFirst.markers.push(builder.generateMarker([], 'first line'));
   expectedPost.appendSection(expectedFirst);
   let expectedSecond = builder.generateMarkupSection('P');
-  expectedSecond.markers.push(builder.generateMarker([], 0, 'second line'));
+  expectedSecond.markers.push(builder.generateMarker([], 'second line'));
   expectedPost.appendSection(expectedSecond);
 
   assert.deepEqual(post, expectedPost);
@@ -46,10 +46,10 @@ test('textnode adjacent to p tag becomes section', (assert) => {
   const post = parser.parse(buildDOM('<p>first line</p>second line'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'first line'));
+  expectedFirst.markers.push(builder.generateMarker([], 'first line'));
   expectedPost.appendSection(expectedFirst);
   let expectedSecond = builder.generateMarkupSection('P', {}, true);
-  expectedSecond.markers.push(builder.generateMarker([], 0, 'second line'));
+  expectedSecond.markers.push(builder.generateMarker([], 'second line'));
   expectedPost.appendSection(expectedSecond);
 
   assert.deepEqual(post, expectedPost);
@@ -59,7 +59,7 @@ test('p tag (section markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('<p>text</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'text'));
+  expectedFirst.markers.push(builder.generateMarker([], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -70,8 +70,8 @@ test('strong tag (stray markup) without a block should create a block', (assert)
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('STRONG')
-  ], 1, 'text'));
+    builder.generateMarkup('STRONG')
+  ], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -81,12 +81,13 @@ test('strong tag with inner em (stray markup) without a block should create a bl
   const post = parser.parse(buildDOM('<strong><em>stray</em> markup tags</strong>.'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
+  let strong = builder.generateMarkup('STRONG');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('STRONG'),
-    builder.generateMarkerType('EM')
-  ], 1, 'stray'));
-  expectedFirst.markers.push(builder.generateMarker([], 1, ' markup tags'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, '.'));
+    strong,
+    builder.generateMarkup('EM')
+  ], 'stray'));
+  expectedFirst.markers.push(builder.generateMarker([strong], ' markup tags'));
+  expectedFirst.markers.push(builder.generateMarker([], '.'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -96,7 +97,7 @@ test('stray text (stray markup) should create a block', (assert) => {
   const post = parser.parse(buildDOM('text'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'text'));
+  expectedFirst.markers.push(builder.generateMarker([], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -106,11 +107,11 @@ test('text node, strong tag, text node (stray markup) without a block should cre
   const post = parser.parse(buildDOM('start <strong>bold</strong> end'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'start '));
+  expectedFirst.markers.push(builder.generateMarker([], 'start '));
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('STRONG')
-  ], 1, 'bold'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, ' end'));
+    builder.generateMarkup('STRONG')
+  ], 'bold'));
+  expectedFirst.markers.push(builder.generateMarker([], ' end'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -121,8 +122,8 @@ test('italic tag (stray markup) without a block should create a block', (assert)
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('EM')
-  ], 1, 'text'));
+    builder.generateMarkup('EM')
+  ], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -132,7 +133,7 @@ test('u tag (stray markup) without a block should strip U and create a block', (
   const post = parser.parse(buildDOM('<u>text</u>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'text'));
+  expectedFirst.markers.push(builder.generateMarker([], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -144,8 +145,8 @@ test('a tag (stray markup) without a block should create a block', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('A', ['href', url])
-  ], 1, 'text'));
+    builder.generateMarkup('A', ['href', url])
+  ], 'text'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -168,8 +169,8 @@ test('sub tag (stray markup) without a block should filter SUB and create a bloc
   const post = parser.parse(buildDOM('footnote<sub>1</sub>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'footnote'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, '1'));
+  expectedFirst.markers.push(builder.generateMarker([], 'footnote'));
+  expectedFirst.markers.push(builder.generateMarker([], '1'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -179,8 +180,8 @@ test('sup tag (stray markup) without a block should filter SUP and create a bloc
   const post = parser.parse(buildDOM('e=mc<sup>2</sup>'));
 
   let expectedFirst = builder.generateMarkupSection('P', {}, true);
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'e=mc'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, '2'));
+  expectedFirst.markers.push(builder.generateMarker([], 'e=mc'));
+  expectedFirst.markers.push(builder.generateMarker([], '2'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -191,11 +192,11 @@ test('list (stray markup) without a block should create a block', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('UL');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('LI')
-  ], 1, 'Item 1'));
+    builder.generateMarkup('LI')
+  ], 'Item 1'));
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('LI')
-  ], 1, 'Item 2'));
+    builder.generateMarkup('LI')
+  ], 'Item 2'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -206,30 +207,35 @@ test('nested tags (section markup) should create a block', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('EM'),
-    builder.generateMarkerType('STRONG')
-  ], 2, 'Double.'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, ' '));
+    builder.generateMarkup('EM'),
+    builder.generateMarkup('STRONG')
+  ], 'Double.'));
+  expectedFirst.markers.push(builder.generateMarker([], ' '));
+  let firstStrong = builder.generateMarkup('STRONG');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('STRONG'),
-    builder.generateMarkerType('EM')
-  ], 1, 'Double staggered'));
-  expectedFirst.markers.push(builder.generateMarker([], 1, ' start.'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, ' '));
+    firstStrong,
+    builder.generateMarkup('EM')
+  ], 'Double staggered'));
+  expectedFirst.markers.push(builder.generateMarker([firstStrong], ' start.'));
+  expectedFirst.markers.push(builder.generateMarker([], ' '));
+  let secondStrong = builder.generateMarkup('STRONG');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('STRONG')
-  ], 0, 'Double '));
+    secondStrong
+  ], 'Double '));
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('EM')
-  ], 2, 'staggered end.'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, ' '));
+    secondStrong,
+    builder.generateMarkup('EM')
+  ], 'staggered end.'));
+  expectedFirst.markers.push(builder.generateMarker([], ' '));
+  let thirdStrong = builder.generateMarkup('STRONG');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('STRONG')
-  ], 0, 'Double '));
+    thirdStrong
+  ], 'Double '));
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('EM')
-  ], 1, 'staggered'));
-  expectedFirst.markers.push(builder.generateMarker([], 1, ' middle.'));
+    thirdStrong,
+    builder.generateMarkup('EM')
+  ], 'staggered'));
+  expectedFirst.markers.push(builder.generateMarker([thirdStrong], ' middle.'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -338,8 +344,8 @@ test('attributes', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('A', ['href', href, 'rel', rel])
-  ], 1, 'Link to google.com'));
+    builder.generateMarkup('A', ['href', href, 'rel', rel])
+  ], 'Link to google.com'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -350,8 +356,8 @@ test('attributes filters out inline styles and classes', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('P');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('B')
-  ], 1, 'test'));
+    builder.generateMarkup('B')
+  ], 'test'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -361,7 +367,7 @@ test('blocks: paragraph', (assert) => {
   const post = parser.parse(buildDOM('<p>TEXT</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'TEXT'));
+  expectedFirst.markers.push(builder.generateMarker([], 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -371,7 +377,7 @@ test('blocks: heading', (assert) => {
   const post = parser.parse(buildDOM('<h2>TEXT</h2>'));
 
   let expectedFirst = builder.generateMarkupSection('H2');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'TEXT'));
+  expectedFirst.markers.push(builder.generateMarker([], 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -381,7 +387,7 @@ test('blocks: subheading', (assert) => {
   const post = parser.parse(buildDOM('<h3>TEXT</h3>'));
 
   let expectedFirst = builder.generateMarkupSection('H3');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'TEXT'));
+  expectedFirst.markers.push(builder.generateMarker([], 'TEXT'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -406,7 +412,7 @@ test('blocks: quote', (assert) => {
   const post = parser.parse(buildDOM('<blockquote>quote</blockquote>'));
 
   let expectedFirst = builder.generateMarkupSection('BLOCKQUOTE');
-  expectedFirst.markers.push(builder.generateMarker([], 0, 'quote'));
+  expectedFirst.markers.push(builder.generateMarker([], 'quote'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -417,12 +423,12 @@ test('blocks: list', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('UL');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('LI')
-  ], 1, 'Item 1'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, ' '));
+    builder.generateMarkup('LI')
+  ], 'Item 1'));
+  expectedFirst.markers.push(builder.generateMarker([], ' '));
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('LI')
-  ], 1, 'Item 2'));
+    builder.generateMarkup('LI')
+  ], 'Item 2'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -433,12 +439,12 @@ test('blocks: ordered list', (assert) => {
 
   let expectedFirst = builder.generateMarkupSection('OL');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('LI')
-  ], 1, 'Item 1'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, ' '));
+    builder.generateMarkup('LI')
+  ], 'Item 1'));
+  expectedFirst.markers.push(builder.generateMarker([], ' '));
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('LI')
-  ], 1, 'Item 2'));
+    builder.generateMarkup('LI')
+  ], 'Item 2'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);
@@ -498,12 +504,13 @@ test('converts tags to mapped values', (assert) => {
   const post = parser.parse(buildDOM('<p><b><i>Converts</i> tags</b>.</p>'));
 
   let expectedFirst = builder.generateMarkupSection('P');
+  let bold = builder.generateMarkup('B');
   expectedFirst.markers.push(builder.generateMarker([
-    builder.generateMarkerType('B'),
-    builder.generateMarkerType('I')
-  ], 1, 'Converts'));
-  expectedFirst.markers.push(builder.generateMarker([], 1, ' tags'));
-  expectedFirst.markers.push(builder.generateMarker([], 0, '.'));
+    bold,
+    builder.generateMarkup('I')
+  ], 'Converts'));
+  expectedFirst.markers.push(builder.generateMarker([bold], ' tags'));
+  expectedFirst.markers.push(builder.generateMarker([], '.'));
   expectedPost.appendSection(expectedFirst);
 
   assert.deepEqual(post, expectedPost);

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -34,7 +34,7 @@ test('#parse doc without marker types', (assert) => {
   const parsed = parser.parse(mobiledoc);
 
   let section = builder.generateMarkupSection('P', [], false);
-  let marker  = builder.generateMarker([], 0, 'hello world');
+  let marker  = builder.generateMarker([], 'hello world');
   section.markers.push(marker);
   post.appendSection(section);
 
@@ -61,13 +61,13 @@ test('#parse doc with marker type', (assert) => {
   const parsed = parser.parse(mobiledoc);
 
   let section = builder.generateMarkupSection('P', [], false);
-  let aMarkerType = builder.generateMarkerType('A', ['href', 'google.com']);
-  let bMarkerType = builder.generateMarkerType('B');
+  let aMarkerType = builder.generateMarkup('A', ['href', 'google.com']);
+  let bMarkerType = builder.generateMarkup('B');
 
   let markers  = [
-    builder.generateMarker([aMarkerType], 0, 'hello'),
-    builder.generateMarker([bMarkerType], 1, 'brave new'),
-    builder.generateMarker([], 1, 'world')
+    builder.generateMarker([aMarkerType], 'hello'),
+    builder.generateMarker([aMarkerType, bMarkerType], 'brave new'),
+    builder.generateMarker([aMarkerType], 'world')
   ];
   section.markers = markers;
   post.appendSection(section);

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -33,7 +33,7 @@ test('#parse doc without marker types', (assert) => {
   ];
   const parsed = parser.parse(mobiledoc);
 
-  let section = builder.generateSection('P', [], false);
+  let section = builder.generateMarkupSection('P', [], false);
   let marker  = builder.generateMarker([], 0, 'hello world');
   section.markers.push(marker);
   post.appendSection(section);
@@ -60,7 +60,7 @@ test('#parse doc with marker type', (assert) => {
   ];
   const parsed = parser.parse(mobiledoc);
 
-  let section = builder.generateSection('P', [], false);
+  let section = builder.generateMarkupSection('P', [], false);
   let aMarkerType = builder.generateMarkerType('A', ['href', 'google.com']);
   let bMarkerType = builder.generateMarkerType('B');
 

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -35,7 +35,7 @@ test('#parse doc without marker types', (assert) => {
 
   let section = builder.generateMarkupSection('P', [], false);
   let marker  = builder.generateMarker([], 'hello world');
-  section.markers.push(marker);
+  section.appendMarker(marker);
   post.appendSection(section);
 
   assert.deepEqual(
@@ -69,7 +69,7 @@ test('#parse doc with marker type', (assert) => {
     builder.generateMarker([aMarkerType, bMarkerType], 'brave new'),
     builder.generateMarker([aMarkerType], 'world')
   ];
-  section.markers = markers;
+  markers.forEach(marker => section.appendMarker(marker));
   post.appendSection(section);
 
   assert.deepEqual(

--- a/tests/unit/parsers/post-test.js
+++ b/tests/unit/parsers/post-test.js
@@ -1,0 +1,61 @@
+const {module, test} = QUnit;
+
+import PostParser from 'content-kit-editor/parsers/post';
+import Helpers from '../../test-helpers';
+
+module('Unit: Parser: PostParser');
+
+test('#parse can parse a single text node', (assert) => {
+  let element = Helpers.dom.makeDOM(t =>
+    t('div', {}, [t.text('some text')])
+  );
+
+  const post = PostParser.parse(element);
+  assert.ok(post, 'gets post');
+  assert.equal(post.sections.length, 1, 'has 1 section');
+
+  const s1 = post.sections[0];
+  assert.equal(s1.markers.length, 1, 's1 has 1 marker');
+  assert.equal(s1.markers[0].value, 'some text', 'has text');
+});
+
+test('#parse can parse a section element', (assert) => {
+  let element = Helpers.dom.makeDOM(t =>
+    t('div', {}, [
+      t('p', {}, [
+        t.text('some text')
+      ])
+    ])
+  );
+
+  const post = PostParser.parse(element);
+  assert.ok(post, 'gets post');
+  assert.equal(post.sections.length, 1, 'has 1 section');
+
+  const s1 = post.sections[0];
+  assert.equal(s1.markers.length, 1, 's1 has 1 marker');
+  assert.equal(s1.markers[0].value, 'some text', 'has text');
+});
+
+test('#parse can parse multiple elements', (assert) => {
+  let element = Helpers.dom.makeDOM(t =>
+    t('div', {}, [
+      t('p', {}, [
+        t.text('some text')
+      ]),
+      t.text('some other text')
+    ])
+  );
+
+  const post = PostParser.parse(element);
+  assert.ok(post, 'gets post');
+  assert.equal(post.sections.length, 2, 'has 2 sections');
+
+  const [s1, s2] = post.sections;
+  assert.equal(s1.markers.length, 1, 's1 has 1 marker');
+  assert.equal(s1.markers[0].value, 'some text');
+
+  assert.equal(s2.markers.length, 1, 's2 has 1 marker');
+  assert.equal(s2.markers[0].value, 'some other text');
+});
+

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -1,0 +1,122 @@
+const {module, test} = QUnit;
+
+import SectionParser from 'content-kit-editor/parsers/section';
+import Helpers from '../../test-helpers';
+
+module('Unit: Parser: SectionParser');
+
+test('#parse parses simple dom', (assert) => {
+  let element = Helpers.dom.makeDOM(
+    'p', {}, [
+      ['text', {value:'hello there'}],
+      ['b', {}, [
+        ['text', {value: 'i am bold'}]
+      ]]
+    ]
+  );
+
+  const section = SectionParser.parse(element);
+  assert.equal(section.type, 'p');
+  assert.equal(section.markers.length, 2, 'has 2 markers');
+  const [m1, m2] = section.markers;
+
+  assert.equal(m1.value, 'hello there');
+  assert.equal(m2.value, 'i am bold');
+  assert.ok(m2.hasMarkup('b'), 'm2 is bold');
+});
+
+test('#parse parses nested markups', (assert) => {
+  let element = Helpers.dom.makeDOM(
+    'p', {}, [
+      ['b', {}, [
+        ['text', {value: 'i am bold'}],
+        ['i', {}, [
+          ['text', {value: 'i am bold and italic'}]
+        ]],
+        ['text', {value: 'i am bold again'}]
+      ]]
+    ]
+  );
+
+  const section = SectionParser.parse(element);
+  assert.equal(section.markers.length, 3, 'has 3 markers');
+  const [m1, m2, m3] = section.markers;
+
+  assert.equal(m1.value, 'i am bold');
+  assert.equal(m2.value, 'i am bold and italic');
+  assert.equal(m3.value, 'i am bold again');
+  assert.ok(m1.hasMarkup('b'), 'm1 is bold');
+  assert.ok(m2.hasMarkup('b') && m2.hasMarkup('i'), 'm2 is bold and i');
+  assert.ok(m3.hasMarkup('b'), 'm3 is bold');
+  assert.ok(!m1.hasMarkup('i') && !m3.hasMarkup('i'), 'm1 and m3 are not i');
+});
+
+test('#parse ignores non-markup elements like spans', (assert) => {
+  let element = Helpers.dom.makeDOM(
+    'p', {}, [
+      ['span', {}, [
+        ['text', {value: 'i was in span'}]
+      ]]
+    ]
+  );
+
+  const section = SectionParser.parse(element);
+  assert.equal(section.type, 'p');
+  assert.equal(section.markers.length, 1, 'has 1 markers');
+  const [m1] = section.markers;
+
+  assert.equal(m1.value, 'i was in span');
+});
+
+test('#parse reads attributes', (assert) => {
+  let element = Helpers.dom.makeDOM(
+    'p', {}, [
+      ['a', {href: 'google.com'}, [
+        ['text', {value: 'i am a link'}]
+      ]]
+    ]
+  );
+  const section = SectionParser.parse(element);
+  assert.equal(section.markers.length, 1, 'has 1 markers');
+  const [m1] = section.markers;
+  assert.equal(m1.value, 'i am a link');
+  assert.ok(m1.hasMarkup('a'), 'has "a" markup');
+  assert.equal(m1.getMarkup('a').attributes.href, 'google.com');
+});
+
+test('#parse joins contiguous text nodes separated by non-markup elements', (assert) => {
+  let element = Helpers.dom.makeDOM(
+    'p', {}, [
+      ['span', {}, [
+        ['text', {value: 'span 1'}]
+      ]],
+      ['span', {}, [
+        ['text', {value: 'span 2'}]
+      ]]
+    ]
+  );
+
+  const section = SectionParser.parse(element);
+  assert.equal(section.type, 'p');
+  assert.equal(section.markers.length, 1, 'has 1 markers');
+  const [m1] = section.markers;
+
+  assert.equal(m1.value, 'span 1span 2');
+});
+
+test('#parse parses a single text node', (assert) => {
+  let element = Helpers.dom.makeDOM(
+    'text', {value: 'raw text'}
+  );
+  const section = SectionParser.parse(element);
+  assert.equal(section.type, 'p');
+  assert.equal(section.markers.length, 1, 'has 1 marker');
+  assert.equal(section.markers[0].value, 'raw text');
+});
+
+// test: a section can parse dom
+
+// test: a section can clear a range:
+//   * truncating the markers on the boundaries
+//   * removing the intermediate markers
+//   * connecting (but not joining) the truncated boundary markers

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -16,7 +16,7 @@ test('#parse parses simple dom', (assert) => {
   );
 
   const section = SectionParser.parse(element);
-  assert.equal(section.type, 'p');
+  assert.equal(section.tagName, 'p');
   assert.equal(section.markers.length, 2, 'has 2 markers');
   const [m1, m2] = section.markers;
 
@@ -61,7 +61,7 @@ test('#parse ignores non-markup elements like spans', (assert) => {
   );
 
   const section = SectionParser.parse(element);
-  assert.equal(section.type, 'p');
+  assert.equal(section.tagName, 'p');
   assert.equal(section.markers.length, 1, 'has 1 markers');
   const [m1] = section.markers;
 
@@ -97,7 +97,7 @@ test('#parse joins contiguous text nodes separated by non-markup elements', (ass
   );
 
   const section = SectionParser.parse(element);
-  assert.equal(section.type, 'p');
+  assert.equal(section.tagName, 'p');
   assert.equal(section.markers.length, 1, 'has 1 markers');
   const [m1] = section.markers;
 
@@ -109,7 +109,7 @@ test('#parse parses a single text node', (assert) => {
     'text', {value: 'raw text'}
   );
   const section = SectionParser.parse(element);
-  assert.equal(section.type, 'p');
+  assert.equal(section.tagName, 'p');
   assert.equal(section.markers.length, 1, 'has 1 marker');
   assert.equal(section.markers[0].value, 'raw text');
 });

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -6,13 +6,13 @@ import Helpers from '../../test-helpers';
 module('Unit: Parser: SectionParser');
 
 test('#parse parses simple dom', (assert) => {
-  let element = Helpers.dom.makeDOM(
-    'p', {}, [
-      ['text', {value:'hello there'}],
-      ['b', {}, [
-        ['text', {value: 'i am bold'}]
-      ]]
-    ]
+  let element = Helpers.dom.makeDOM(t =>
+    t('p', {}, [
+      t.text('hello there'),
+      t('b', {}, [
+        t.text('i am bold')
+      ])
+    ])
   );
 
   const section = SectionParser.parse(element);
@@ -26,16 +26,16 @@ test('#parse parses simple dom', (assert) => {
 });
 
 test('#parse parses nested markups', (assert) => {
-  let element = Helpers.dom.makeDOM(
-    'p', {}, [
-      ['b', {}, [
-        ['text', {value: 'i am bold'}],
-        ['i', {}, [
-          ['text', {value: 'i am bold and italic'}]
-        ]],
-        ['text', {value: 'i am bold again'}]
-      ]]
-    ]
+  let element = Helpers.dom.makeDOM(t =>
+    t('p', {}, [
+      t('b', {}, [
+        t.text('i am bold'),
+        t('i', {}, [
+          t.text('i am bold and italic')
+        ]),
+        t.text('i am bold again')
+      ])
+    ])
   );
 
   const section = SectionParser.parse(element);
@@ -52,12 +52,12 @@ test('#parse parses nested markups', (assert) => {
 });
 
 test('#parse ignores non-markup elements like spans', (assert) => {
-  let element = Helpers.dom.makeDOM(
-    'p', {}, [
-      ['span', {}, [
-        ['text', {value: 'i was in span'}]
-      ]]
-    ]
+  let element = Helpers.dom.makeDOM(t =>
+    t('p', {}, [
+      t('span', {}, [
+        t.text('i was in span')
+      ])
+    ])
   );
 
   const section = SectionParser.parse(element);
@@ -69,12 +69,12 @@ test('#parse ignores non-markup elements like spans', (assert) => {
 });
 
 test('#parse reads attributes', (assert) => {
-  let element = Helpers.dom.makeDOM(
-    'p', {}, [
-      ['a', {href: 'google.com'}, [
-        ['text', {value: 'i am a link'}]
-      ]]
-    ]
+  let element = Helpers.dom.makeDOM(t =>
+    t('p', {}, [
+      t('a', {href: 'google.com'}, [
+        t.text('i am a link')
+      ])
+    ])
   );
   const section = SectionParser.parse(element);
   assert.equal(section.markers.length, 1, 'has 1 markers');
@@ -85,15 +85,15 @@ test('#parse reads attributes', (assert) => {
 });
 
 test('#parse joins contiguous text nodes separated by non-markup elements', (assert) => {
-  let element = Helpers.dom.makeDOM(
-    'p', {}, [
-      ['span', {}, [
-        ['text', {value: 'span 1'}]
-      ]],
-      ['span', {}, [
-        ['text', {value: 'span 2'}]
-      ]]
-    ]
+  let element = Helpers.dom.makeDOM(t =>
+    t('p', {}, [
+      t('span', {}, [
+        t.text('span 1')
+      ]),
+      t('span', {}, [
+        t.text('span 2')
+      ])
+    ])
   );
 
   const section = SectionParser.parse(element);
@@ -105,8 +105,8 @@ test('#parse joins contiguous text nodes separated by non-markup elements', (ass
 });
 
 test('#parse parses a single text node', (assert) => {
-  let element = Helpers.dom.makeDOM(
-    'text', {value: 'raw text'}
+  let element = Helpers.dom.makeDOM(h => 
+    h.text('raw text')
   );
   const section = SectionParser.parse(element);
   assert.equal(section.tagName, 'p');

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -38,9 +38,9 @@ test("It renders a dirty post", (assert) => {
 
 test("It renders a dirty post with un-rendered sections", (assert) => {
   let post = builder.generatePost();
-  let sectionA = builder.generateSection('P');
+  let sectionA = builder.generateMarkupSection('P');
   post.appendSection(sectionA);
-  let sectionB = builder.generateSection('P');
+  let sectionB = builder.generateMarkupSection('P');
   post.appendSection(sectionB);
 
   let renderNode = new RenderNode(post);
@@ -65,7 +65,7 @@ test("It renders a dirty post with un-rendered sections", (assert) => {
 [
   {
     name: 'markup',
-    section: (builder) => builder.generateSection('P')
+    section: (builder) => builder.generateMarkupSection('P')
   },
   {
     name: 'image',
@@ -111,7 +111,7 @@ test("It renders a dirty post with un-rendered sections", (assert) => {
 
 test('renders a post with marker', (assert) => {
   let post = builder.generatePost();
-  let section = builder.generateSection('P');
+  let section = builder.generateMarkupSection('P');
   post.appendSection(section);
   section.markers.push(
     builder.generateMarker([

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -115,8 +115,8 @@ test('renders a post with marker', (assert) => {
   post.appendSection(section);
   section.markers.push(
     builder.generateMarker([
-      builder.generateMarkerType('STRONG')
-    ], 1, 'Hi')
+      builder.generateMarkup('STRONG')
+    ], 'Hi')
   );
 
   let node = new RenderNode(post);

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -113,7 +113,7 @@ test('renders a post with marker', (assert) => {
   let post = builder.generatePost();
   let section = builder.generateMarkupSection('P');
   post.appendSection(section);
-  section.markers.push(
+  section.appendMarker(
     builder.generateMarker([
       builder.generateMarkup('STRONG')
     ], 'Hi')

--- a/tests/unit/renderers/mobiledoc-test.js
+++ b/tests/unit/renderers/mobiledoc-test.js
@@ -24,13 +24,13 @@ test('renders a post with marker', (assert) => {
   post.appendSection(section);
   section.markers.push(
     builder.generateMarker([
-      builder.generateMarkerType('STRONG')
-    ], 1, 'Hi')
+      builder.generateMarkup('STRONG')
+    ], 'Hi')
   );
   let mobiledoc = render(post);
   assert.deepEqual(mobiledoc, [
     [
-      ['STRONG']
+      ['strong']
     ],
     [
       [1, 'P', [

--- a/tests/unit/renderers/mobiledoc-test.js
+++ b/tests/unit/renderers/mobiledoc-test.js
@@ -22,7 +22,7 @@ test('renders a post with marker', (assert) => {
   let post = builder.generatePost();
   let section = builder.generateMarkupSection('P');
   post.appendSection(section);
-  section.markers.push(
+  section.appendMarker(
     builder.generateMarker([
       builder.generateMarkup('STRONG')
     ], 'Hi')
@@ -35,6 +35,35 @@ test('renders a post with marker', (assert) => {
     [
       [1, 'P', [
         [[0], 1, 'Hi']
+      ]]
+    ]
+  ]);
+});
+
+test('renders a post section with markers sharing a markup', (assert) => {
+  let post = builder.generatePost();
+  let section = builder.generateMarkupSection('P');
+  post.appendSection(section);
+  let markup = builder.generateMarkup('STRONG');
+  section.appendMarker(
+    builder.generateMarker([
+      markup
+    ], 'Hi')
+  );
+  section.appendMarker(
+    builder.generateMarker([
+      markup
+    ], ' Guy')
+  );
+  let mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, [
+    [
+      ['strong']
+    ],
+    [
+      [1, 'P', [
+        [[0], 0, 'Hi'],
+        [[], 1, ' Guy']
       ]]
     ]
   ]);

--- a/tests/unit/renderers/mobiledoc-test.js
+++ b/tests/unit/renderers/mobiledoc-test.js
@@ -20,7 +20,7 @@ test('renders a blank post', (assert) => {
 
 test('renders a post with marker', (assert) => {
   let post = builder.generatePost();
-  let section = builder.generateSection('P');
+  let section = builder.generateMarkupSection('P');
   post.appendSection(section);
   section.markers.push(
     builder.generateMarker([


### PR DESCRIPTION
WIP to use `Post`, `Section`, `Marker`, `Markup` models to build the internal `post` model that the editor has.

I started this as a WIP to see what it would take to be able to semantically handle section-breaking actions (like hitting `<enter>` or clicking the "h2" on the toolbar) and section-joining actions (highlighting text across sections and deleting, putting the cursor at the beginning of a section and deleting). I started with the `Marker` concept representing text with possible markups applied to it and thinking of the methods a `Marker` would need in order to handle the cases mentioned above. I rewrote the post/section parser to use the marker/markup construct internally as well. This fixes the problem of ignorable (ie `<span>`) elements causing the parser to generate separate markers for the same string of text.

A `Post` hasMany `sections`, a `Section` hasMany `markers`, a `Marker` has a tagName and many `markups`.

Adds a `PostParser` (from DOM to Post) and its `SectionParser`. The `PostParser` is simpler than the existing dom parser, partly because it makes the simplifying assumption that if it is parsing dom into a post, only the top-level element's children are potentially valid sections. It will ignore invalid (from its perspective) dom like a nested section tag inside another (`<p>first section<p>inner section</p> continue first section</p>`).

In order to be usable, these need to happen:
  * [ ] Enhance SectionParser to parse Image sections
  * [ ] Change Mobiledoc renderer to consume this format (the major change is that markers don't have `open` and `close` properties on them anymore)
  * [ ] The post-builder is probably not necessary, because all the primitives exist and have their own constructors (`new Section()`, `new Marker()`, `new Markup()`).

The goal of this was to eventually be able to add event listeners for section-breaking (`<enter>` key) and section-joining (`delete` key) actions that the user might take and apply those directly to the internal `post` model rather than the current heuristic of attempting to detect which sections might have been affected or removed.