### PR TITLE
Refactor editor to delegate selection methods to `Cursor`

### DIFF
--- a/src/js/commands/base.js
+++ b/src/js/commands/base.js
@@ -1,13 +1,13 @@
-function Command(options) {
-  options = options || {};
-  var command = this;
-  var name = options.name;
-  var prompt = options.prompt;
-  command.name = name;
-  command.button = options.button || name;
-  if (prompt) { command.prompt = prompt; }
+export default class Command {
+  constructor(options={}) {
+    var command = this;
+    var name = options.name;
+    var prompt = options.prompt;
+    command.name = name;
+    command.button = options.button || name;
+    if (prompt) { command.prompt = prompt; }
+  }
+
+  exec() {/* override in subclass */}
+  unexec() {/* override in subclass */}
 }
-
-Command.prototype.exec = function() {};
-
-export default Command;

--- a/src/js/commands/card.js
+++ b/src/js/commands/card.js
@@ -1,28 +1,24 @@
 import Command from './base';
-import { inherit } from 'content-kit-utils';
 
 function injectCardBlock(/* cardName, cardPayload, editor, index */) {
   throw new Error('Unimplemented: BlockModel and Type.CARD are no longer things');
 }
 
-function CardCommand() {
-  Command.call(this, {
-    name: 'card',
-    button: '<i>CA</i>'
-  });
-}
-inherit(CardCommand, Command);
+export default class CardCommand extends Command {
+  constructor() {
+    super({
+      name: 'card',
+      button: '<i>CA</i>'
+    });
+  }
 
-CardCommand.prototype = {
-  exec: function() {
-    CardCommand._super.prototype.exec.call(this);
-    var editor = this.editorContext;
-    var currentEditingIndex = editor.getCurrentBlockIndex();
+  exec() {
+    super.exec();
+    const editor = this.editor;
+    const currentEditingIndex = editor.getCurrentBlockIndex();
 
-    var cardName = 'pick-color';
-    var cardPayload = { options: ['red', 'blue'] };
+    const cardName = 'pick-color';
+    const cardPayload = { options: ['red', 'blue'] };
     injectCardBlock(cardName, cardPayload, editor, currentEditingIndex);
   }
-};
-
-export default CardCommand;
+}

--- a/src/js/commands/format-block.js
+++ b/src/js/commands/format-block.js
@@ -1,8 +1,21 @@
 import TextFormatCommand from './text-format';
+import {
+  any
+} from '../utils/array-utils';
 
 class FormatBlockCommand extends TextFormatCommand {
-  constructor(options={}) {
+  constructor(editor, options={}) {
     super(options);
+    this.editor = editor;
+  }
+
+  isActive() {
+    const editor = this.editor;
+    const activeSections = editor.activeSections;
+
+    return any(activeSections, section => {
+      return any(this.mappedTags, t => section.tagName === t);
+    });
   }
 
   exec() {
@@ -15,8 +28,6 @@ class FormatBlockCommand extends TextFormatCommand {
     });
 
     editor.rerender();
-    editor.trigger('update'); // FIXME -- should be handled by editor
-
     editor.selectSections(activeSections);
   }
 
@@ -29,8 +40,6 @@ class FormatBlockCommand extends TextFormatCommand {
     });
 
     editor.rerender();
-    editor.trigger('update'); // FIXME -- should be handled by editor
-
     editor.selectSections(activeSections);
   }
 }

--- a/src/js/commands/format-block.js
+++ b/src/js/commands/format-block.js
@@ -1,36 +1,38 @@
 import TextFormatCommand from './text-format';
-import { getSelectionBlockElement, selectNode } from '../utils/selection-utils';
-import { inherit } from 'content-kit-utils';
 
-function FormatBlockCommand(options) {
-  options = options || {};
-  options.action = 'formatBlock';
-  TextFormatCommand.call(this, options);
-}
-inherit(FormatBlockCommand, TextFormatCommand);
-
-FormatBlockCommand.prototype.exec = function() {
-  var tag = this.tag;
-  // Brackets neccessary for certain browsers
-  var value =  '<' + tag + '>';
-  var blockElement = getSelectionBlockElement();
-  // Allow block commands to be toggled back to a text block
-  if(tag === blockElement.tagName.toLowerCase()) {
-    throw new Error('Unimplemented: Type.BOLD.paragraph must be replaced');
-    /*
-    value = Type.PARAGRAPH.tag;
-    */
-  } else {
-    // Flattens the selection before applying the block format.
-    // Otherwise, undesirable nested blocks can occur.
-    // TODO: would love to be able to remove this
-    var flatNode = document.createTextNode(blockElement.textContent);
-    blockElement.parentNode.insertBefore(flatNode, blockElement);
-    blockElement.parentNode.removeChild(blockElement);
-    selectNode(flatNode);
+class FormatBlockCommand extends TextFormatCommand {
+  constructor(options={}) {
+    super(options);
   }
 
-  FormatBlockCommand._super.prototype.exec.call(this, value);
-};
+  exec() {
+    const editor = this.editor;
+    const activeSections = editor.activeSections;
+
+    activeSections.forEach(s => {
+      editor.resetSectionMarkers(s);
+      editor.setSectionTagName(s, this.tag);
+    });
+
+    editor.rerender();
+    editor.trigger('update'); // FIXME -- should be handled by editor
+
+    editor.selectSections(activeSections);
+  }
+
+  unexec() {
+    const editor = this.editor;
+    const activeSections = editor.activeSections;
+
+    activeSections.forEach(s => {
+      editor.resetSectionTagName(s);
+    });
+
+    editor.rerender();
+    editor.trigger('update'); // FIXME -- should be handled by editor
+
+    editor.selectSections(activeSections);
+  }
+}
 
 export default FormatBlockCommand;

--- a/src/js/commands/heading.js
+++ b/src/js/commands/heading.js
@@ -5,7 +5,7 @@ export default class HeadingCommand extends FormatBlockCommand {
     const options = {
       name: 'heading',
       tag: 'h2',
-      button: '<i class="ck-icon-heading"></i>1'
+      button: '<i class="ck-icon-heading"></i>2'
     };
     super(editor, options);
   }

--- a/src/js/commands/heading.js
+++ b/src/js/commands/heading.js
@@ -1,12 +1,12 @@
 import FormatBlockCommand from './format-block';
 
 export default class HeadingCommand extends FormatBlockCommand {
-  constructor() {
+  constructor(editor) {
     const options = {
       name: 'heading',
       tag: 'h2',
       button: '<i class="ck-icon-heading"></i>1'
     };
-    super(options);
+    super(editor, options);
   }
 }

--- a/src/js/commands/heading.js
+++ b/src/js/commands/heading.js
@@ -1,13 +1,12 @@
 import FormatBlockCommand from './format-block';
-import { inherit } from 'content-kit-utils';
 
-function HeadingCommand() {
-  FormatBlockCommand.call(this, {
-    name: 'heading',
-    tag: 'h2',
-    button: '<i class="ck-icon-heading"></i>1'
-  });
+export default class HeadingCommand extends FormatBlockCommand {
+  constructor() {
+    const options = {
+      name: 'heading',
+      tag: 'h2',
+      button: '<i class="ck-icon-heading"></i>1'
+    };
+    super(options);
+  }
 }
-inherit(HeadingCommand, FormatBlockCommand);
-
-export default HeadingCommand;

--- a/src/js/commands/image.js
+++ b/src/js/commands/image.js
@@ -1,6 +1,5 @@
 import Command from './base';
 import Message from '../views/message';
-import { inherit } from 'content-kit-utils';
 import { FileUploader } from '../utils/http-utils';
 import { generateBuilder } from '../utils/post-builder';
 
@@ -10,24 +9,24 @@ function readFromFile(file, callback) {
   reader.readAsDataURL(file);
 }
 
-function ImageCommand(options) {
-  Command.call(this, {
-    name: 'image',
-    button: '<i class="ck-icon-image"></i>'
-  });
-  this.uploader = new FileUploader({
-    url: options.serviceUrl,
-    maxFileSize: 5000000
-  });
-}
-inherit(ImageCommand, Command);
+export default class ImageCommand extends Command {
+  constructor(options={}) {
+    super({
+      name: 'image',
+      button: '<i class="ck-icon-image"></i>'
+    });
+    this.uploader = new FileUploader({
+      url: options.serviceUrl,
+      maxFileSize: 5000000
+    });
+  }
 
-ImageCommand.prototype = {
   exec() {
-    ImageCommand._super.prototype.exec.call(this);
+    super.exec();
     var fileInput = this.getFileInput();
     fileInput.dispatchEvent(new MouseEvent('click', { bubbles: false }));
-  },
+  }
+
   getFileInput() {
     if (this._fileInput) {
       return this._fileInput;
@@ -41,15 +40,16 @@ ImageCommand.prototype = {
     document.body.appendChild(fileInput);
 
     return fileInput;
-  },
+  }
+
   handleFile({target: fileInput}) {
     let imageSection;
 
     let file = fileInput.files[0];
     readFromFile(file, (base64Image) => {
       imageSection = generateBuilder().generateImageSection(base64Image);
-      this.editorContext.insertSectionAtCursor(imageSection);
-      this.editorContext.rerender();
+      this.editor.insertSectionAtCursor(imageSection);
+      this.editor.rerender();
     });
 
     this.uploader.upload({
@@ -61,16 +61,14 @@ ImageCommand.prototype = {
         if (!error && response && response.url) {
           imageSection.src = response.url;
           imageSection.renderNode.markDirty();
-          this.editorContext.rerender();
-          this.editorContext.trigger('update');
+          this.editor.rerender();
+          this.editor.trigger('update');
         } else {
-          this.editorContext.removeSection(imageSection);
+          this.editor.removeSection(imageSection);
           new Message().showError(error.message || 'Error uploading image');
         }
-        this.editorContext.rerender();
+        this.editor.rerender();
       }
     });
   }
-};
-
-export default ImageCommand;
+}

--- a/src/js/commands/oembed.js
+++ b/src/js/commands/oembed.js
@@ -33,9 +33,7 @@ inherit(OEmbedCommand, Command);
 
 OEmbedCommand.prototype.exec = function(url) {
   var command = this;
-  // var editorContext = command.editorContext;
   var embedIntent = command.embedIntent;
-  // var index = editorContext.getCurrentBlockIndex();
 
   embedIntent.showLoading();
   this.embedService.fetch({

--- a/src/js/commands/quote.js
+++ b/src/js/commands/quote.js
@@ -1,13 +1,11 @@
 import FormatBlockCommand from './format-block';
-import { inherit } from 'content-kit-utils';
 
-function QuoteCommand() {
-  FormatBlockCommand.call(this, {
-    name: 'quote',
-    tag: 'blockquote',
-    button: '<i class="ck-icon-quote"></i>'
-  });
+export default class QuoteCommand extends FormatBlockCommand {
+  constructor(editor) {
+    super(editor, {
+      name: 'quote',
+      tag: 'blockquote',
+      button: '<i class="ck-icon-quote"></i>'
+    });
+  }
 }
-inherit(QuoteCommand, FormatBlockCommand);
-
-export default QuoteCommand;

--- a/src/js/commands/subheading.js
+++ b/src/js/commands/subheading.js
@@ -1,13 +1,11 @@
 import FormatBlockCommand from './format-block';
-import { inherit } from 'content-kit-utils';
 
-function SubheadingCommand() {
-  FormatBlockCommand.call(this, {
-    name: 'subheading',
-    tag: 'h3',
-    button: '<i class="ck-icon-heading"></i>2'
-  });
+export default class SubheadingCommand extends FormatBlockCommand {
+  constructor(editor) {
+    super(editor, {
+      name: 'subheading',
+      tag: 'h3',
+      button: '<i class="ck-icon-heading"></i>2'
+    });
+  }
 }
-inherit(SubheadingCommand, FormatBlockCommand);
-
-export default SubheadingCommand;

--- a/src/js/commands/subheading.js
+++ b/src/js/commands/subheading.js
@@ -5,7 +5,7 @@ export default class SubheadingCommand extends FormatBlockCommand {
     super(editor, {
       name: 'subheading',
       tag: 'h3',
-      button: '<i class="ck-icon-heading"></i>2'
+      button: '<i class="ck-icon-heading"></i>3'
     });
   }
 }

--- a/src/js/commands/text-format.js
+++ b/src/js/commands/text-format.js
@@ -1,24 +1,21 @@
 import Command from './base';
-import { inherit } from 'content-kit-utils';
 
-function TextFormatCommand(options) {
-  options = options || {};
-  Command.call(this, options);
-  this.tag = options.tag;
-  this.mappedTags = options.mappedTags || [];
-  this.mappedTags.push(this.tag);
-  this.action = options.action || this.name;
-  this.removeAction = options.removeAction || this.action;
-}
-inherit(TextFormatCommand, Command);
+export default class TextFormatCommand extends Command {
+  constructor(options={}) {
+    super(options);
 
-TextFormatCommand.prototype = {
-  exec: function(value) {
+    this.tag = options.tag;
+    this.mappedTags = options.mappedTags || [];
+    this.mappedTags.push(this.tag);
+    this.action = options.action || this.name;
+    this.removeAction = options.removeAction || this.action;
+  }
+
+  exec(value) {
     document.execCommand(this.action, false, value || null);
-  },
-  unexec: function(value) {
+  }
+
+  unexec(value) {
     document.execCommand(this.removeAction, false, value || null);
   }
-};
-
-export default TextFormatCommand;
+}

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -2,6 +2,7 @@ import TextFormatToolbar  from '../views/text-format-toolbar';
 import Tooltip from '../views/tooltip';
 import EmbedIntent from '../views/embed-intent';
 
+import ReversibleToolbarButton from '../views/reversible-toolbar-button';
 import BoldCommand from '../commands/bold';
 import ItalicCommand from '../commands/italic';
 import LinkCommand from '../commands/link';
@@ -56,10 +57,7 @@ const defaults = {
   textFormatCommands: [
     new BoldCommand(),
     new ItalicCommand(),
-    new LinkCommand(),
-    new QuoteCommand(),
-    new HeadingCommand(),
-    new SubheadingCommand()
+    new LinkCommand()
   ],
   embedCommands: [
     new ImageCommand({ serviceUrl: '/upload' }),
@@ -177,6 +175,23 @@ function initEmbedCommands(editor) {
   }
 }
 
+function makeButtons(editor) {
+  const headingCommand = new HeadingCommand(editor);
+  const headingButton = new ReversibleToolbarButton(headingCommand, editor);
+
+  const subheadingCommand = new SubheadingCommand(editor);
+  const subheadingButton = new ReversibleToolbarButton(subheadingCommand, editor);
+
+  const quoteCommand = new QuoteCommand(editor);
+  const quoteButton = new ReversibleToolbarButton(quoteCommand, editor);
+
+  return [
+    headingButton,
+    subheadingButton,
+    quoteButton
+  ];
+}
+
 /**
  * @class Editor
  * An individual Editor
@@ -225,7 +240,10 @@ class Editor {
     this.addView(new TextFormatToolbar({
       editor: this,
       rootElement: element,
+      // FIXME -- eventually all the commands should migrate to being buttons
+      // that can be added
       commands: this.textFormatCommands,
+      buttons: makeButtons(this),
       sticky: this.stickyToolbar
     }));
 
@@ -430,6 +448,7 @@ class Editor {
 
   selectSections(sections) {
     this.cursor.selectSections(sections);
+    this.hasSelection();
   }
 
   getActiveSections() {

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -266,7 +266,7 @@ class Editor {
   rerender() {
     let postRenderNode = this.post.renderNode;
 
-    // if we haven't rendered this renderNode before, mark it dirty
+    // if we haven't rendered this post's renderNode before, mark it dirty
     if (!postRenderNode.element) {
       postRenderNode.element = this.element;
       postRenderNode.markDirty();
@@ -428,6 +428,10 @@ class Editor {
     this.trigger('update');
   }
 
+  selectSections(sections) {
+    this.cursor.selectSections(sections);
+  }
+
   getActiveSections() {
     const cursor = this.cursor;
     return cursor.activeSections;
@@ -535,7 +539,7 @@ class Editor {
       rightOffset
     } = this.cursor.offsets;
 
-    // The cursor will lose its textNode if we have parsed (and thus rerendered)
+    // The cursor will lose its textNode if we have reparsed (and thus will rerender, below)
     // its section. Ensure the cursor is placed where it should be after render.
     //
     // New sections are presumed clean, and thus do not get rerendered and lose
@@ -568,6 +572,44 @@ class Editor {
         rightOffset
       );
     }
+  }
+
+  get cursorSelection() {
+    return this.cursor.cursorSelection;
+  }
+
+  /*
+   * Returns the active sections. If the cursor selection is collapsed this will be
+   * an array of 1 item. Else will return an array containing each section that is either
+   * wholly or partly contained by the cursor selection.
+   *
+   * @return {array} The sections from the cursor's selection start to the selection end
+   */
+  get activeSections() {
+    return this.cursor.activeSections;
+  }
+
+  /*
+   * Clear the markups from each of the section's markers
+   */
+  resetSectionMarkers(section) {
+    section.markers.forEach(m => {
+      m.clearMarkups();
+      m.renderNode.markDirty();
+    });
+  }
+
+  /*
+   * Change the tag name for the given section
+   */
+  setSectionTagName(section, tagName) {
+    section.setTagName(tagName);
+    section.renderNode.markDirty();
+  }
+
+  resetSectionTagName(section) {
+    section.resetTagName();
+    section.renderNode.markDirty();
   }
 
   reparseSection(section) {

--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -74,7 +74,7 @@ export default class Cursor {
 
     const { startContainer, endContainer } = range;
     const isSectionElement = (element) => {
-      return detect(sections, (s) => s.renderNode.element === element);
+      return detect(sections, s => s.renderNode.element === element);
     };
     const {result:startSection} = detectParentNode(startContainer, isSectionElement);
     const {result:endSection} = detectParentNode(endContainer, isSectionElement);
@@ -99,6 +99,19 @@ export default class Cursor {
       selection.removeAllRanges();
     }
     selection.addRange(r);
+  }
+
+  selectSections(sections) {
+    const startSection = sections[0],
+          endSection  = sections[sections.length - 1];
+
+    const startNode = startSection.markers[0].renderNode.element,
+          endNode   = endSection.markers[endSection.markers.length - 1].renderNode.element;
+
+    const startOffset = 0,
+          endOffset = endNode.textContent.length;
+
+    this.moveToNode(startNode, startOffset, endNode, endOffset);
   }
 
   moveToNode(node, offset=0, endNode=node, endOffset=offset) {

--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -8,12 +8,10 @@ import {
 } from '../utils/selection-utils';
 
 import {
-  detectParentNode,
-  containsNode,
-  walkTextNodes
+  detectParentNode
 } from '../utils/dom-utils';
 
-const Cursor = class Cursor {
+export default class Cursor {
   constructor(editor) {
     this.editor = editor;
     this.renderTree = editor._renderTree;
@@ -31,13 +29,6 @@ const Cursor = class Cursor {
 
   get selection() {
     return window.getSelection();
-  }
-
-  /**
-   * the offset from the left edge of the section
-   */
-  get leftOffset() {
-    return this.offsets.leftOffset;
   }
 
   get offsets() {
@@ -73,58 +64,6 @@ const Cursor = class Cursor {
     };
   }
 
-  get activeMarkers() {
-    const firstSection = this.activeSections[0];
-    if (!firstSection) { return []; }
-    const firstSectionElement = firstSection.renderNode.element;
-
-    const {
-      leftNode, rightNode,
-      leftOffset, rightOffset
-    } = this.offsets;
-
-    let textLeftOffset = 0,
-        textRightOffset = 0,
-        foundLeft = false,
-        foundRight = false;
-
-    walkTextNodes(firstSectionElement, (textNode) => {
-      let textLength = textNode.textContent.length;
-
-      if (!foundLeft) {
-        if (containsNode(leftNode, textNode)) {
-          textLeftOffset += leftOffset;
-          foundLeft = true;
-        } else {
-          textLeftOffset += textLength;
-        }
-      }
-      if (!foundRight) {
-        if (containsNode(rightNode, textNode)) {
-          textRightOffset += rightOffset;
-          foundRight = true;
-        } else {
-          textRightOffset += textLength;
-        }
-      }
-    });
-
-    // get section element
-    //   walk it until we find one containing the left node, adding up textContent length along the way
-    //   add the selection offset in the left node -- this is the offset in the parent textContent
-    //   repeat for right node (subtract the remaining chars after selection offset) -- this is the end offset
-    //
-    //   walk the section's markers, adding up length. Each marker with length >= offset and <= end offset is active
-
-    const leftMarker = firstSection.markerContaining(textLeftOffset, true);
-    const rightMarker = firstSection.markerContaining(textRightOffset, false);
-
-    const leftMarkerIndex = firstSection.markers.indexOf(leftMarker),
-          rightMarkerIndex = firstSection.markers.indexOf(rightMarker) + 1;
-
-    return firstSection.markers.slice(leftMarkerIndex, rightMarkerIndex);
-  }
-
   get activeSections() {
     const { sections } = this.post;
     const selection = this.selection;
@@ -135,9 +74,7 @@ const Cursor = class Cursor {
 
     const { startContainer, endContainer } = range;
     const isSectionElement = (element) => {
-      return detect(sections, (section) => {
-        return section.renderNode.element === element;
-      });
+      return detect(sections, (s) => s.renderNode.element === element);
     };
     const {result:startSection} = detectParentNode(startContainer, isSectionElement);
     const {result:endSection} = detectParentNode(endContainer, isSectionElement);
@@ -174,7 +111,4 @@ const Cursor = class Cursor {
     }
     selection.addRange(r);
   }
-};
-
-export default Cursor;
-
+}

--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -70,7 +70,9 @@ export default class Cursor {
     const { rangeCount } = selection;
     const range = rangeCount > 0 && selection.getRangeAt(0);
 
-    if (!range) { throw new Error('Unable to get activeSections because no range'); }
+    if (!range) {
+      return [];
+    }
 
     const { startContainer, endContainer } = range;
     const isSectionElement = (element) => {

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -30,6 +30,10 @@ const Marker = class Marker {
     this.value = this.value.substr(offset);
   }
 
+  clearMarkups() {
+    this.markups = [];
+  }
+
   addMarkup(markup) {
     this.markups.push(markup);
   }

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -4,6 +4,8 @@ export const VALID_MARKUP_SECTION_TAGNAMES = [
 ];
 export const MARKUP_SECTION_TYPE = 'markup-section';
 
+const normalizeTagName = (tagName) => tagName.toLowerCase();
+
 export default class Section {
   constructor(tagName, markers=[]) {
     this.markers = [];
@@ -12,6 +14,18 @@ export default class Section {
     this.element = null;
 
     markers.forEach(m => this.appendMarker(m));
+  }
+
+  setTagName(newTagName) {
+    newTagName = normalizeTagName(newTagName);
+    if (VALID_MARKUP_SECTION_TAGNAMES.indexOf(newTagName) === -1) {
+      throw new Error(`Cannot change section tagName to "${newTagName}`);
+    }
+    this.tagName = newTagName;
+  }
+
+  resetTagName() {
+    this.tagName = DEFAULT_TAG_NAME;
   }
 
   prependMarker(marker) {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -1,10 +1,12 @@
-export const DEFAULT_TAG_NAME = 'p';
+import {
+  normalizeTagName
+} from '../utils/dom-utils';
+
+export const DEFAULT_TAG_NAME = normalizeTagName('p');
 export const VALID_MARKUP_SECTION_TAGNAMES = [
   'p', 'h3', 'h2', 'h1', 'blockquote', 'ul', 'ol'
-];
+].map(normalizeTagName);
 export const MARKUP_SECTION_TYPE = 'markup-section';
-
-const normalizeTagName = (tagName) => tagName.toLowerCase();
 
 export default class Section {
   constructor(tagName, markers=[]) {
@@ -14,6 +16,14 @@ export default class Section {
     this.element = null;
 
     markers.forEach(m => this.appendMarker(m));
+  }
+
+  set tagName(val) {
+    this._tagName = normalizeTagName(val);
+  }
+
+  get tagName() {
+    return this._tagName;
   }
 
   setTagName(newTagName) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -17,14 +17,16 @@ export default class Post {
     this.removeSection(section);
   }
   insertSectionAfter(section, previousSection) {
-    var i, l;
-    for (i=0,l=this.sections.length;i<l;i++) {
+    let foundIndex = -1;
+
+    for (let i=0; i<this.sections.length; i++) {
       if (this.sections[i] === previousSection) {
-        this.sections.splice(i+1, 0, section);
-        return;
+        foundIndex = i;
+        break;
       }
     }
-    throw new Error('Previous section was not found in post.sections');
+
+    this.sections.splice(foundIndex+1, 0, section);
   }
   removeSection(section) {
     var i, l;

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -52,7 +52,7 @@ export default {
 
     // walk up from the textNode until the rootNode, converting each
     // parentNode into a markup
-    function collectMarkups(textNode, rootNode) {
+    const  collectMarkups = (textNode, rootNode) =>{
       let markups = [];
       let currentNode = textNode.parentNode;
       while (currentNode && currentNode !== rootNode) {
@@ -64,7 +64,7 @@ export default {
         currentNode = currentNode.parentNode;
       }
       return markups;
-    }
+    };
 
     let seenRenderNodes = [];
     let previousMarker;
@@ -117,15 +117,15 @@ export default {
       previousMarker = marker;
     });
 
-    // schedule any nodes that were not marked as seen
-    let node = section.renderNode.firstChild;
-    while (node) {
-      if (seenRenderNodes.indexOf(node) === -1) {
+    // remove any nodes that were not marked as seen
+    let renderNode = section.renderNode.firstChild;
+    while (renderNode) {
+      if (seenRenderNodes.indexOf(renderNode) === -1) {
         // remove it
-        node.scheduleForRemoval();
+        renderNode.scheduleForRemoval();
       }
 
-      node = node.nextSibling;
+      renderNode = renderNode.nextSibling;
     }
   }
 };

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -32,8 +32,8 @@ function penultimateParentOf(element, parentElement) {
   return element;
 }
 
-function renderMarkupSection(doc, section) {
-  var element = doc.createElement(section.tagName);
+function renderMarkupSection(section) {
+  var element = document.createElement(section.tagName);
   section.element = element;
   return element;
 }
@@ -103,8 +103,17 @@ class Visitor {
   }
 
   [MARKUP_SECTION_TYPE](renderNode, section, visit) {
-    if (!renderNode.element) {
-      let element = renderMarkupSection(window.document, section);
+    let originalElement = renderNode.element;
+    const hasRendered = !!originalElement;
+
+    // Always rerender the section -- its tag name or attributes may have changed.
+    // TODO make this smarter, only rerendering and replacing the element when necessary
+    let element = renderMarkupSection(section);
+    renderNode.element = element;
+
+    if (!hasRendered) {
+      let element = renderNode.element;
+
       if (renderNode.previousSibling) {
         let previousElement = renderNode.previousSibling.element;
         let nextElement = previousElement.nextSibling;
@@ -115,7 +124,8 @@ class Visitor {
       if (!element.parentNode) {
         renderNode.parentNode.element.appendChild(element);
       }
-      renderNode.element = element;
+    } else {
+      renderNode.parentNode.element.replaceChild(element, originalElement);
     }
 
     // remove all elements so that we can rerender

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -6,6 +6,16 @@ function detect(array, callback) {
   }
 }
 
+function any(array, callback) {
+  for (let i=0; i<array.length; i++) {
+    if (callback(array[i])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Useful for array-like things that aren't
  * actually arrays, like NodeList
@@ -18,5 +28,6 @@ function forEach(enumerable, callback) {
 
 export {
   detect,
-  forEach
+  forEach,
+  any
 };

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -116,6 +116,10 @@ function addClassName(element, className) {
   element.classList.add(className);
 }
 
+function normalizeTagName(tagName) {
+  return tagName.toLowerCase();
+}
+
 export {
   detectParentNode,
   containsNode,
@@ -124,5 +128,6 @@ export {
   getAttributesArray,
   walkDOMUntil,
   walkTextNodes,
-  addClassName
+  addClassName,
+  normalizeTagName
 };

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -71,7 +71,6 @@ function walkDOMUntil(topNode, conditionFn=() => {}) {
   }
 }
 
-
 // see https://github.com/webmodules/node-contains/blob/master/index.js
 function containsNode(parentNode, childNode) {
   const isSame = () => parentNode === childNode;
@@ -112,6 +111,11 @@ function getAttributesArray(element) {
   return result;
 }
 
+function addClassName(element, className) {
+  // FIXME-IE IE10+
+  element.classList.add(className);
+}
+
 export {
   detectParentNode,
   containsNode,
@@ -119,5 +123,6 @@ export {
   getAttributes,
   getAttributesArray,
   walkDOMUntil,
-  walkTextNodes
+  walkTextNodes,
+  addClassName
 };

--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -105,20 +105,6 @@ function selectNode(node) {
   selection.addRange(range);
 }
 
-function getCursorOffsetInElement(element) {
-  // http://stackoverflow.com/questions/4811822/get-a-ranges-start-and-end-offsets-relative-to-its-parent-container/4812022#4812022
-  var caretOffset = 0;
-  var selection = window.getSelection();
-  if (selection.rangeCount > 0) {
-    var range = selection.getRangeAt(0);
-    var preCaretRange = range.cloneRange();
-    preCaretRange.selectNodeContents(element);
-    preCaretRange.setEnd(range.endContainer, range.endOffset);
-    caretOffset = preCaretRange.toString().length;
-  }
-  return caretOffset;
-}
-
 export {
   getDirectionOfSelection,
   getSelectionElement,
@@ -128,7 +114,6 @@ export {
   tagsInSelection,
   restoreRange,
   selectNode,
-  getCursorOffsetInElement,
   clearSelection,
   isSelectionInElement
 };

--- a/src/js/views/reversible-toolbar-button.js
+++ b/src/js/views/reversible-toolbar-button.js
@@ -1,0 +1,62 @@
+import mixin from '../utils/mixin';
+import EventListenerMixin from '../utils/event-listener';
+
+const ELEMENT_TYPE = 'button';
+const BUTTON_CLASS_NAME = 'ck-toolbar-btn';
+
+class ReversibleToolbarButton {
+  constructor(command, editor) {
+    this.command = command;
+    this.editor = editor;
+    this.element = this.createElement();
+    this.active = false;
+
+    this.addEventListener(this.element, 'mouseup', e => this.handleClick(e));
+    this.editor.on('selection', () => this.updateActiveState());
+    this.editor.on('selectionUpdated', () => this.updateActiveState());
+    this.editor.on('selectionEnded', () => this.updateActiveState());
+  }
+
+  // These are here to match the API of the ToolbarButton class
+  setInactive() {}
+  setActive() {}
+
+  handleClick(e) {
+    e.stopPropagation();
+
+    if (this.active) {
+      this.command.unexec();
+    } else {
+      this.command.exec();
+    }
+  }
+
+  updateActiveState() {
+    this.active = this.command.isActive();
+  }
+
+  createElement() {
+    const element = document.createElement(ELEMENT_TYPE);
+    element.className = BUTTON_CLASS_NAME;
+    element.innerHTML = this.command.button;
+    element.title = this.command.name;
+    return element;
+  }
+
+  set active(val) {
+    this._active = val;
+    if (this._active) {
+      this.element.className = BUTTON_CLASS_NAME + ' active';
+    } else {
+      this.element.className = BUTTON_CLASS_NAME;
+    }
+  }
+
+  get active() {
+    return this._active;
+  }
+}
+
+mixin(ReversibleToolbarButton, EventListenerMixin);
+
+export default ReversibleToolbarButton;

--- a/src/js/views/toolbar.js
+++ b/src/js/views/toolbar.js
@@ -34,9 +34,6 @@ class Toolbar extends View {
     options.classNames = ['ck-toolbar'];
     super(options);
 
-    let commands = options.commands;
-    let commandCount = commands && commands.length;
-
     this.setDirection(options.direction || ToolbarDirection.TOP);
     this.editor = options.editor || null;
     this.embedIntent = options.embedIntent || null;
@@ -50,9 +47,8 @@ class Toolbar extends View {
     this.contentElement.appendChild(this.buttonContainerElement);
     this.element.appendChild(this.contentElement);
 
-    for(let i = 0; i < commandCount; i++) {
-      this.addCommand(commands[i]);
-    }
+    (options.buttons || []).forEach(b => this.addButton(b));
+    (options.commands || []).forEach(c => this.addCommand(c));
 
     // Closes prompt if displayed when changing selection
     this.addEventListener(document, 'mouseup', () => {
@@ -73,6 +69,10 @@ class Toolbar extends View {
     command.editor = this.editor;
     command.embedIntent = this.embedIntent;
     let button = new ToolbarButton({command: command, toolbar: this});
+    this.addButton(button);
+  }
+
+  addButton(button) {
     this.buttons.push(button);
     this.buttonContainerElement.appendChild(button.element);
   }

--- a/src/js/views/toolbar.js
+++ b/src/js/views/toolbar.js
@@ -70,7 +70,7 @@ class Toolbar extends View {
   }
 
   addCommand(command) {
-    command.editorContext = this.editor;
+    command.editor = this.editor;
     command.embedIntent = this.embedIntent;
     let button = new ToolbarButton({command: command, toolbar: this});
     this.buttons.push(button);

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -131,7 +131,8 @@ test('highlighting heading text activates toolbar button', (assert) => {
       Helpers.dom.triggerEvent(document, 'mouseup');
 
       setTimeout(() => {
-        assertActiveToolbarButton(assert, 'heading');
+        assertActiveToolbarButton(assert, 'heading',
+                                  'heading button is active when text is selected');
 
         done();
       });
@@ -156,6 +157,32 @@ test('when heading text is highlighted, clicking heading button turns it to plai
         done();
       });
     });
+  });
+});
+
+test('clicking multiple heading buttons keeps the correct ones active', (assert) => {
+  const done = assert.async();
+
+  setTimeout(() => {
+    // click subheading, makes its button active, changes the display
+    clickToolbarButton(assert, 'subheading');
+    assert.hasElement('#editor h3:contains(THIS IS A TEST)');
+    assertActiveToolbarButton(assert, 'subheading');
+    assertInactiveToolbarButton(assert, 'heading');
+
+    // click heading, makes its button active and no others, changes display
+    clickToolbarButton(assert, 'heading');
+    assert.hasElement('#editor h2:contains(THIS IS A TEST)');
+    assertActiveToolbarButton(assert, 'heading');
+    assertInactiveToolbarButton(assert, 'subheading');
+
+    // click heading again, removes headline from display, no active buttons
+    clickToolbarButton(assert, 'heading');
+    assert.hasElement('#editor p:contains(THIS IS A TEST)');
+    assertInactiveToolbarButton(assert, 'heading');
+    assertInactiveToolbarButton(assert, 'subheading');
+
+    done();
   });
 });
 

--- a/tests/helpers/assertions.js
+++ b/tests/helpers/assertions.js
@@ -1,5 +1,7 @@
 /* global QUnit, $ */
 
+import DOMHelper from './dom';
+
 export default function registerAssertions() {
   QUnit.assert.hasElement = function(selector, message=`hasElement "${selector}"`) {
     let found = $(selector);
@@ -11,5 +13,13 @@ export default function registerAssertions() {
     let found = $(selector);
     this.push(found.length === 0, found.length, selector, message);
     return found;
+  };
+
+  QUnit.assert.selectedText = function(text, message=`selectedText "${text}"`) {
+    const selected = DOMHelper.getSelectedText();
+    this.push(selected === text,
+              selected,
+              text,
+              message);
   };
 }

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -104,6 +104,28 @@ function makeDOM(tree) {
   return tree(_buildDOM);
 }
 
+function getSelectedText() {
+  const selection = window.getSelection();
+  if (selection.rangeCount === 0) {
+    return null;
+  } else if (selection.rangeCount > 1) {
+    // FIXME?
+    throw new Error('Unable to get selected text for multiple ranges');
+  } else {
+    const {
+      anchorNode, anchorOffset,
+      focusNode, focusOffset
+    } = selection;
+
+    if (anchorNode !== focusNode) {
+      // FIXME
+      throw new Error('Unable to get selected text when multiple nodes are selected');
+    } else {
+      return anchorNode.textContent.slice(anchorOffset, focusOffset);
+    }
+  }
+}
+
 // returns the node and the offset that the cursor is on
 function getCursorPosition() {
   const selection = window.getSelection();
@@ -113,7 +135,7 @@ function getCursorPosition() {
   };
 }
 
-export default {
+const DOMHelper = {
   moveCursorTo,
   selectText,
   clearSelection,
@@ -121,5 +143,8 @@ export default {
   triggerKeyEvent,
   makeDOM,
   KEY_CODES,
-  getCursorPosition
+  getCursorPosition,
+  getSelectedText
 };
+
+export default DOMHelper;

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -42,7 +42,7 @@ test('creating an editor adds EDITOR_ELEMENT_CLASS_NAME if not there', (assert) 
   editorElement.className = 'abc def';
 
   var editor = new Editor(document.getElementById('editor1'));
-  const hasClass = (className) => editor.element.className.indexOf(className) !== -1;
+  const hasClass = (className) => editor.element.classList.contains(className);
   assert.ok(hasClass(EDITOR_ELEMENT_CLASS_NAME), 'has editor el class name');
   assert.ok(hasClass('abc') && hasClass('def'), 'preserves existing class names');
 });

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -1,5 +1,6 @@
 import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
 import Editor, { EDITOR_ELEMENT_CLASS_NAME } from 'content-kit-editor/editor/editor';
+import { normalizeTagName } from 'content-kit-editor/utils/dom-utils';
 
 const { module, test } = window.QUnit;
 
@@ -66,7 +67,7 @@ test('editor parses and renders mobiledoc format', (assert) => {
     sections: [
       [],
       [
-        [1, 'P', [
+        [1, normalizeTagName('p'), [
           [[], 0, 'hello world']
         ]]
       ]

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -1,5 +1,5 @@
 import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
-import Editor from 'content-kit-editor/editor/editor';
+import Editor, { EDITOR_ELEMENT_CLASS_NAME } from 'content-kit-editor/editor/editor';
 
 const { module, test } = window.QUnit;
 
@@ -35,7 +35,16 @@ test('creating an editor without a class name adds appropriate class', (assert) 
   editorElement.className = '';
 
   var editor = new Editor(document.getElementById('editor1'));
-  assert.equal(editor.element.className, 'ck-editor');
+  assert.equal(editor.element.className, EDITOR_ELEMENT_CLASS_NAME);
+});
+
+test('creating an editor adds EDITOR_ELEMENT_CLASS_NAME if not there', (assert) => {
+  editorElement.className = 'abc def';
+
+  var editor = new Editor(document.getElementById('editor1'));
+  const hasClass = (className) => editor.element.className.indexOf(className) !== -1;
+  assert.ok(hasClass(EDITOR_ELEMENT_CLASS_NAME), 'has editor el class name');
+  assert.ok(hasClass('abc') && hasClass('def'), 'preserves existing class names');
 });
 
 test('editor fires update event', (assert) => {

--- a/tests/unit/renderers/mobiledoc-test.js
+++ b/tests/unit/renderers/mobiledoc-test.js
@@ -1,5 +1,6 @@
 import MobiledocRenderer, { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
 import { generateBuilder } from 'content-kit-editor/utils/post-builder';
+import { normalizeTagName } from 'content-kit-editor/utils/dom-utils';
 
 const { module, test } = window.QUnit;
 const render = MobiledocRenderer.render;
@@ -37,7 +38,7 @@ test('renders a post with marker', (assert) => {
         ['strong']
       ],
       [
-        [1, 'P', [
+        [1, normalizeTagName('P'), [
           [[0], 1, 'Hi']
         ]]
       ]
@@ -68,7 +69,7 @@ test('renders a post section with markers sharing a markup', (assert) => {
         ['strong']
       ],
       [
-        [1, 'P', [
+        [1, normalizeTagName('P'), [
           [[0], 0, 'Hi'],
           [[], 1, ' Guy']
         ]]


### PR DESCRIPTION
 * remove unused methods from cursor and editor
 * add `ReversibleToolbarButton` to represent a button that can be `exec`'d and `unexec`'d. Some duplication with the code for buttons that already exist, but this moves closer to being able to clean up all buttons
 * Change the `TextFormatToolbar` to be instantiated with buttons in addition to commands. Eventually only buttons should be added to it.
 * Change all the block format commands (heading, subheading, 
 * Several tests surrounding applying/unapplying block format headings and ensuring that their buttons stay active/inactive as necessary
 * small change: heading button now says "h2" and subheading button says "h3", because those are the tags that they apply
 * add `normalizeTagName` method in dom utils, use it for methods interacting with markup sections.

>>  * `Post.insertSectionAfter` can take a null reference section, like the DOM method `insertAfter`

I was wrong about that ^^. For one thing the DOM node method is `insertBefore` and it's unclear from the docs whether it can always deal with a null reference node. I may change this back at some point.

I believe this is ready to go, now. Next step is to add code to split markers at the text selection, which unblocks the ability to apply markup commands (bold, italic, etc). I'll address that in a separate PR.


cc @mixonic 