### PR TITLE
Fixes mobiledoc sample & removes jQuery from usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ var simpleMobiledoc = {
     [1, "p", [
       [[], 0, "Welcome to Content-Kit"]
     ]]
-  ]
+  ]]
 };
-var element = $('#editor')[0];
+var element = document.querySelector('#editor');
 var options = { mobiledoc: simpleMobiledoc };
 var editor = new ContentKit.Editor(element, options);
 ```


### PR DESCRIPTION
Ok, I know, this is a totally lame attempt at a first commit :grin: 

I noticed there was a missing closing bracket in the 'usage' code example in the README.md.

Whilst I was there, I also swapped out the jQuery snippet to one that doesn't require jQuery. This is totally a personal preference thing so am happy to revert that if you prefer to keep it as it was.

- simpleMobiledoc sample was missing a closing bracket
- switched from jQuery to document.querySelector