### PR TITLE
37 selection deletion

### DIFF
--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -144,6 +144,12 @@ export default class Cursor {
     this.moveToNode(startNode, startOffset, endNode, endOffset);
   }
 
+  /**
+   * @param {textNode} node
+   * @param {integer} offset
+   * @param {textNode} endNode (default: node)
+   * @param {integer} endOffset (default: offset)
+   */
   moveToNode(node, offset=0, endNode=node, endOffset=offset) {
     let r = document.createRange();
     r.setStart(node, offset);

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -6,10 +6,6 @@ import {
 import { detect } from 'content-kit-editor/utils/array-utils';
 
 const Marker = class Marker {
-  static createBlank() {
-    return new Marker('');
-  }
-
   constructor(value='', markups=[]) {
     this.value = value;
     this.markups = [];

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -6,6 +6,10 @@ import {
 import { detect } from 'content-kit-editor/utils/array-utils';
 
 const Marker = class Marker {
+  static createBlank() {
+    return new Marker('');
+  }
+
   constructor(value='', markups=[]) {
     this.value = value;
     this.markups = [];

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -26,6 +26,10 @@ export default class Section {
     return this._tagName;
   }
 
+  isEmpty() {
+    return this.markers.length === 0;
+  }
+
   setTagName(newTagName) {
     newTagName = normalizeTagName(newTagName);
     if (VALID_MARKUP_SECTION_TAGNAMES.indexOf(newTagName) === -1) {

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -45,7 +45,7 @@ export default class PostNodeBuilder {
   }
 
   createBlankMarker() {
-    return new Marker('__BLANK__');
+    return new Marker('');
   }
 
   createMarkup(tagName, attributes) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -1,4 +1,3 @@
-import Marker from './marker';
 export const POST_TYPE = 'post';
 
 // FIXME: making sections a linked-list would greatly improve this
@@ -46,7 +45,7 @@ export default class Post {
     // add a blank marker to any sections that are now empty
     changedSections.forEach(section => {
       if (section.isEmpty()) {
-        section.appendMarker(Marker.createBlank());
+        section.appendMarker(this.builder.createBlankMarker());
       }
     });
 

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -1,3 +1,4 @@
+import Marker from './marker';
 export const POST_TYPE = 'post';
 
 // FIXME: making sections a linked-list would greatly improve this
@@ -19,6 +20,53 @@ export default class Post {
     this.insertSectionAfter(newSection, section);
     this.removeSection(section);
   }
+  cutMarkers(markers) {
+    let firstSection = markers[0].section,
+        lastSection  = markers[markers.length - 1].section;
+
+    let currentSection = firstSection;
+    let removedSections = [],
+        changedSections = [firstSection, lastSection];
+
+    let previousMarker = markers[0].previousSibling;
+
+    markers.forEach(marker => {
+      if (marker.section !== currentSection) { // this marker is in a section we haven't seen yet
+        if (marker.section !== firstSection &&
+            marker.section !== lastSection) {
+          // section is wholly contained by markers, and can be removed
+          removedSections.push(marker.section);
+        }
+      }
+
+      currentSection = marker.section;
+      currentSection.removeMarker(marker);
+    });
+
+    // add a blank marker to any sections that are now empty
+    changedSections.forEach(section => {
+      if (section.isEmpty()) {
+        section.appendMarker(Marker.createBlank());
+      }
+    });
+
+    let currentMarker, currentOffset;
+
+    if (previousMarker) {
+      currentMarker = previousMarker;
+      currentOffset = currentMarker.length;
+    } else {
+      currentMarker = firstSection.markers[0];
+      currentOffset = 0;
+    }
+
+    if (firstSection !== lastSection) {
+      firstSection.join(lastSection);
+      removedSections.push(lastSection);
+    }
+
+    return {changedSections, removedSections, currentMarker, currentOffset};
+  }
   /**
    * Invoke `callbackFn` for all markers between the startMarker and endMarker (inclusive),
    * across sections
@@ -34,7 +82,7 @@ export default class Post {
         currentMarker = currentMarker.nextSibling;
       } else {
         let nextSection = currentMarker.section.nextSibling;
-        currentMarker = nextSection.markers[0];
+        currentMarker = nextSection && nextSection.markers[0];
       }
     }
   }

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -35,34 +35,6 @@ module('Acceptance: Editor commands', {
   }
 });
 
-function getToolbarButton(assert, name) {
-  let btnSelector = `.ck-toolbar-btn[title="${name}"]`;
-  return assert.hasElement(btnSelector);
-}
-
-function assertToolbarVisible(assert) {
-  return assert.hasElement(`.ck-toolbar`);
-}
-
-function assertToolbarHidden(assert) {
-  return assert.hasNoElement(`.ck-toolbar`);
-}
-
-function clickToolbarButton(assert, name) {
-  const button = getToolbarButton(assert, name);
-  Helpers.dom.triggerEvent(button[0], 'click');
-}
-
-function assertActiveToolbarButton(assert, buttonTitle) {
-  const button = getToolbarButton(assert, buttonTitle);
-  assert.ok(button.is('.active'), `button ${buttonTitle} is active`);
-}
-
-function assertInactiveToolbarButton(assert, buttonTitle) {
-  const button = getToolbarButton(assert, buttonTitle);
-  assert.ok(!button.is('.active'), `button ${buttonTitle} is not active`);
-}
-
 test('when text is highlighted, shows toolbar', (assert) => {
   let done = assert.async();
 
@@ -80,7 +52,7 @@ test('highlight text, click "bold" button bolds text', (assert) => {
   let done = assert.async();
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'bold');
+    Helpers.toolbar.clickButton(assert, 'bold');
     assert.hasElement('#editor strong:contains(IS A)');
 
     done();
@@ -91,7 +63,7 @@ test('highlight text, click "heading" button turns text into h2 header', (assert
   const done = assert.async();
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'heading');
+    Helpers.toolbar.clickButton(assert, 'heading');
     assert.hasElement('#editor h2:contains(THIS IS A TEST)');
     assert.selectedText('THIS IS A TEST', 'expands selection to entire section');
 
@@ -103,25 +75,25 @@ test('highlighting heading text activates toolbar button', (assert) => {
   const done = assert.async();
 
   setTimeout(() => {
-    assertToolbarVisible(assert);
-    assertInactiveToolbarButton(assert, 'heading');
+    Helpers.toolbar.assertVisible(assert);
+    Helpers.toolbar.assertInactiveButton(assert, 'heading');
 
-    clickToolbarButton(assert, 'heading');
+    Helpers.toolbar.clickButton(assert, 'heading');
 
-    assertActiveToolbarButton(assert, 'heading');
+    Helpers.toolbar.assertActiveButton(assert, 'heading');
 
     // FIXME must actually trigger the mouseup
     Helpers.dom.clearSelection();
     Helpers.dom.triggerEvent(document, 'mouseup');
 
     setTimeout(() => {
-      assertToolbarHidden(assert);
+      Helpers.toolbar.assertHidden(assert);
 
       Helpers.dom.selectText(selectedText, editorElement);
       Helpers.dom.triggerEvent(document, 'mouseup');
 
       setTimeout(() => {
-        assertActiveToolbarButton(assert, 'heading',
+        Helpers.toolbar.assertActiveButton(assert, 'heading',
                                   'heading button is active when text is selected');
 
         done();
@@ -134,11 +106,11 @@ test('when heading text is highlighted, clicking heading button turns it to plai
   const done = assert.async();
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'heading');
+    Helpers.toolbar.clickButton(assert, 'heading');
     assert.hasElement('#editor h2:contains(THIS IS A TEST)');
 
     setTimeout(() => {
-      clickToolbarButton(assert, 'heading');
+      Helpers.toolbar.clickButton(assert, 'heading');
 
       setTimeout(() => {
         assert.hasNoElement('#editor h2:contains(THIS IS A TEST)');
@@ -155,22 +127,22 @@ test('clicking multiple heading buttons keeps the correct ones active', (assert)
 
   setTimeout(() => {
     // click subheading, makes its button active, changes the display
-    clickToolbarButton(assert, 'subheading');
+    Helpers.toolbar.clickButton(assert, 'subheading');
     assert.hasElement('#editor h3:contains(THIS IS A TEST)');
-    assertActiveToolbarButton(assert, 'subheading');
-    assertInactiveToolbarButton(assert, 'heading');
+    Helpers.toolbar.assertActiveButton(assert, 'subheading');
+    Helpers.toolbar.assertInactiveButton(assert, 'heading');
 
     // click heading, makes its button active and no others, changes display
-    clickToolbarButton(assert, 'heading');
+    Helpers.toolbar.clickButton(assert, 'heading');
     assert.hasElement('#editor h2:contains(THIS IS A TEST)');
-    assertActiveToolbarButton(assert, 'heading');
-    assertInactiveToolbarButton(assert, 'subheading');
+    Helpers.toolbar.assertActiveButton(assert, 'heading');
+    Helpers.toolbar.assertInactiveButton(assert, 'subheading');
 
     // click heading again, removes headline from display, no active buttons
-    clickToolbarButton(assert, 'heading');
+    Helpers.toolbar.clickButton(assert, 'heading');
     assert.hasElement('#editor p:contains(THIS IS A TEST)');
-    assertInactiveToolbarButton(assert, 'heading');
-    assertInactiveToolbarButton(assert, 'subheading');
+    Helpers.toolbar.assertInactiveButton(assert, 'heading');
+    Helpers.toolbar.assertInactiveButton(assert, 'subheading');
 
     done();
   });
@@ -180,7 +152,7 @@ test('highlight text, click "subheading" button turns text into h3 header', (ass
   const done = assert.async();
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'subheading');
+    Helpers.toolbar.clickButton(assert, 'subheading');
     assert.hasElement('#editor h3:contains(THIS IS A TEST)');
 
     done();
@@ -191,7 +163,7 @@ test('highlight text, click "quote" button turns text into blockquote', (assert)
   const done = assert.async();
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'quote');
+    Helpers.toolbar.clickButton(assert, 'quote');
     assert.hasElement('#editor blockquote:contains(THIS IS A TEST)');
 
     done();
@@ -204,7 +176,7 @@ Helpers.skipInPhantom('highlight text, click "link" button shows input for URL, 
   const done = assert.async();
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'link');
+    Helpers.toolbar.clickButton(assert, 'link');
     let input = assert.hasElement('.ck-toolbar-prompt input');
     let url = 'http://google.com';
     $(input).val(url);
@@ -220,22 +192,22 @@ test('highlighting bold text shows bold button as active', (assert) => {
   const done = assert.async();
 
   setTimeout(() => {
-    assertInactiveToolbarButton(assert, 'bold', 'precond - bold button is not active');
-    clickToolbarButton(assert, 'bold');
-    assertActiveToolbarButton(assert, 'bold');
+    Helpers.toolbar.assertInactiveButton(assert, 'bold', 'precond - bold button is not active');
+    Helpers.toolbar.clickButton(assert, 'bold');
+    Helpers.toolbar.assertActiveButton(assert, 'bold');
 
     Helpers.dom.clearSelection();
     Helpers.dom.triggerEvent(document, 'mouseup');
 
     setTimeout(() => {
-      assertToolbarHidden(assert);
+      Helpers.toolbar.assertHidden(assert);
 
       Helpers.dom.selectText(selectedText, editorElement);
       Helpers.dom.triggerEvent(document, 'mouseup');
 
       setTimeout(() => {
-        assertToolbarVisible(assert);
-        assertActiveToolbarButton(assert, 'bold');
+        Helpers.toolbar.assertVisible(assert);
+        Helpers.toolbar.assertActiveButton(assert, 'bold');
 
         done();
       });
@@ -247,9 +219,9 @@ test('click bold button applies bold to selected text', (assert) => {
   const done = assert.async();
 
   setTimeout(() => {
-    assertInactiveToolbarButton(assert, 'bold', 'precond - bold button is not active');
-    clickToolbarButton(assert, 'bold');
-    assertActiveToolbarButton(assert, 'bold');
+    Helpers.toolbar.assertInactiveButton(assert, 'bold', 'precond - bold button is not active');
+    Helpers.toolbar.clickButton(assert, 'bold');
+    Helpers.toolbar.assertActiveButton(assert, 'bold');
 
     assert.hasNoElement('#editor strong:contains(THIS)');
     assert.hasNoElement('#editor strong:contains(TEST)');
@@ -257,10 +229,10 @@ test('click bold button applies bold to selected text', (assert) => {
 
     assert.selectedText(selectedText);
 
-    clickToolbarButton(assert, 'bold');
+    Helpers.toolbar.clickButton(assert, 'bold');
 
     assert.hasNoElement('#editor strong:contains(IS A)', 'bold text is no longer bold');
-    assertInactiveToolbarButton(assert, 'bold');
+    Helpers.toolbar.assertInactiveButton(assert, 'bold');
 
     done();
   });
@@ -270,9 +242,9 @@ test('can unbold part of a larger set of bold text', (assert) => {
   const done = assert.async();
 
   setTimeout(() => {
-    assertInactiveToolbarButton(assert, 'bold', 'precond - bold button is not active');
-    clickToolbarButton(assert, 'bold');
-    assertActiveToolbarButton(assert, 'bold');
+    Helpers.toolbar.assertInactiveButton(assert, 'bold', 'precond - bold button is not active');
+    Helpers.toolbar.clickButton(assert, 'bold');
+    Helpers.toolbar.assertActiveButton(assert, 'bold');
 
     assert.hasElement('#editor strong:contains(IS A)');
 
@@ -280,9 +252,9 @@ test('can unbold part of a larger set of bold text', (assert) => {
     Helpers.dom.triggerEvent(document, 'mouseup');
 
     setTimeout(() => {
-      assertToolbarVisible(assert);
-      assertActiveToolbarButton(assert, 'bold');
-      clickToolbarButton(assert, 'bold');
+      Helpers.toolbar.assertVisible(assert);
+      Helpers.toolbar.assertActiveButton(assert, 'bold');
+      Helpers.toolbar.clickButton(assert, 'bold');
 
       assert.hasElement('#editor strong:contains(I)', 'unselected text is bold');
       assert.hasNoElement('#editor strong:contains(IS A)', 'unselected text is bold');
@@ -297,16 +269,16 @@ test('can italicize text', (assert) => {
   const done = assert.async();
 
   setTimeout(() => {
-    assertInactiveToolbarButton(assert, 'italic');
-    clickToolbarButton(assert, 'italic');
+    Helpers.toolbar.assertInactiveButton(assert, 'italic');
+    Helpers.toolbar.clickButton(assert, 'italic');
 
     assert.hasElement('#editor em:contains(IS A)');
     assert.selectedText('IS A');
-    assertActiveToolbarButton(assert, 'italic');
+    Helpers.toolbar.assertActiveButton(assert, 'italic');
 
-    clickToolbarButton(assert, 'italic');
+    Helpers.toolbar.clickButton(assert, 'italic');
     assert.hasNoElement('#editor em:contains(IS A)');
-    assertInactiveToolbarButton(assert, 'italic');
+    Helpers.toolbar.assertInactiveButton(assert, 'italic');
 
     done();
   });

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -147,7 +147,7 @@ test('deleting across 1 section removes it, joins the 2 boundary sections', (ass
                     'remaining paragraph has correct text');
 });
 
-Helpers.skipInPhantom('keystroke of delete removes that character', (assert) => {
+test('keystroke of delete removes that character', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith3Sections});
   const getFirstTextNode = () => {
     return editor.element.
@@ -157,11 +157,7 @@ Helpers.skipInPhantom('keystroke of delete removes that character', (assert) => 
   const textNode = getFirstTextNode();
   Helpers.dom.moveCursorTo(textNode, 1);
 
-  const runDefault = Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
-  if (runDefault) {
-    document.execCommand('delete', false);
-    Helpers.dom.triggerEvent(editor.element, 'input');
-  }
+  Helpers.dom.triggerDelete(editor);
 
   assert.equal($('#editor p:eq(0)').html(), 'irst section',
                'deletes first character');
@@ -172,7 +168,7 @@ Helpers.skipInPhantom('keystroke of delete removes that character', (assert) => 
                    'cursor is at start of new text node');
 });
 
-Helpers.skipInPhantom('keystroke of delete when cursor is at beginning of marker removes character from previous marker', (assert) => {
+test('keystroke of delete when cursor is at beginning of marker removes character from previous marker', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Markers});
   const textNode = editor.element.
                     firstChild.    // section
@@ -181,11 +177,7 @@ Helpers.skipInPhantom('keystroke of delete when cursor is at beginning of marker
   assert.ok(!!textNode, 'gets text node');
   Helpers.dom.moveCursorTo(textNode, 0);
 
-  const runDefault = Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
-  if (runDefault) {
-    document.execCommand('delete', false);
-    Helpers.dom.triggerEvent(editor.element, 'input');
-  }
+  Helpers.dom.triggerDelete(editor);
 
   assert.equal($('#editor p:eq(0)').html(), '<b>bol</b>plain',
                'deletes last character of previous marker');
@@ -199,7 +191,7 @@ Helpers.skipInPhantom('keystroke of delete when cursor is at beginning of marker
                   'cursor moves to end of previous text node');
 });
 
-Helpers.skipInPhantom('keystroke of delete when cursor is after only char in only marker of section removes character', (assert) => {
+test('keystroke of delete when cursor is after only char in only marker of section removes character', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Character});
   const getTextNode = () => editor.element.
                                   firstChild. // section
@@ -209,11 +201,7 @@ Helpers.skipInPhantom('keystroke of delete when cursor is after only char in onl
   assert.ok(!!textNode, 'gets text node');
   Helpers.dom.moveCursorTo(textNode, 1);
 
-  const runDefault = Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
-  if (runDefault) {
-    document.execCommand('delete', false);
-    Helpers.dom.triggerEvent(editor.element, 'input');
-  }
+  Helpers.dom.triggerDelete(editor);
 
   assert.equal($('#editor p:eq(0)')[0].textContent, UNPRINTABLE_CHARACTER,
                'deletes only character');
@@ -251,7 +239,7 @@ Helpers.skipInPhantom('keystroke of character results in unprintable being remov
                   'cursor moves to end of m text node');
 });
 
-Helpers.skipInPhantom('keystroke of delete at start of section joins with previous section', (assert) => {
+test('keystroke of delete at start of section joins with previous section', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
 
   let secondSectionTextNode = editor.element.childNodes[1].firstChild;
@@ -260,13 +248,7 @@ Helpers.skipInPhantom('keystroke of delete at start of section joins with previo
                'finds section section text node');
 
   Helpers.dom.moveCursorTo(secondSectionTextNode, 0);
-
-  const runDefault = Helpers.dom.triggerKeyEvent(document, 'keydown',
-                                                 Helpers.dom.KEY_CODES.DELETE);
-  if (runDefault) {
-    document.execCommand('delete', false);
-    Helpers.dom.triggerEvent(editor.element, 'input');
-  }
+  Helpers.dom.triggerDelete(editor);
 
   assert.equal(editor.element.childNodes.length, 1, 'only 1 section remaining');
 
@@ -283,7 +265,7 @@ Helpers.skipInPhantom('keystroke of delete at start of section joins with previo
 });
 
 
-Helpers.skipInPhantom('keystroke of delete at start of first section does nothing', (assert) => {
+test('keystroke of delete at start of first section does nothing', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
 
   let firstSectionTextNode = editor.element.childNodes[0].firstChild;
@@ -293,12 +275,7 @@ Helpers.skipInPhantom('keystroke of delete at start of first section does nothin
 
   Helpers.dom.moveCursorTo(firstSectionTextNode, 0);
 
-  const runDefault = Helpers.dom.triggerKeyEvent(document, 'keydown',
-                                                 Helpers.dom.KEY_CODES.DELETE);
-  if (runDefault) {
-    document.execCommand('delete', false);
-    Helpers.dom.triggerEvent(editor.element, 'input');
-  }
+  Helpers.dom.triggerDelete(editor);
 
   assert.equal(editor.element.childNodes.length, 2, 'still 2 sections');
   firstSectionTextNode = editor.element.childNodes[0].firstChild;

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -61,7 +61,7 @@ test('selecting an entire section and deleting removes it', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
 
   Helpers.dom.selectText('second section', editorElement);
-  Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+  Helpers.dom.triggerDelete(editor);
 
   assert.hasElement('p:contains(first section)');
   assert.hasNoElement('p:contains(second section)', 'deletes contents of second section');
@@ -81,7 +81,7 @@ test('selecting text in a section and deleting deletes it', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
 
   Helpers.dom.selectText('cond sec', editorElement);
-  Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+  Helpers.dom.triggerDelete(editor);
 
   assert.hasElement('p:contains(first section)', 'first section unchanged');
   assert.hasNoElement('p:contains(second section)', 'second section is no longer there');
@@ -103,23 +103,13 @@ test('selecting text across sections and deleting joins sections', (assert) => {
 
   Helpers.dom.selectText('t section', firstSection,
                          'second s', secondSection);
-  Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+  Helpers.dom.triggerDelete(editor);
 
   assert.hasElement('p:contains(firsection)');
   assert.hasNoElement('p:contains(first section)');
   assert.hasNoElement('p:contains(second section)');
   assert.equal($('#editor p').length, 1, 'only 1 section after deleting to join');
 });
-
-function getToolbarButton(assert, name) {
-  let btnSelector = `.ck-toolbar-btn[title="${name}"]`;
-  return assert.hasElement(btnSelector);
-}
-
-function clickToolbarButton(assert, name) {
-  const button = getToolbarButton(assert, name);
-  Helpers.dom.triggerEvent(button[0], 'click');
-}
 
 test('selecting text across markers and deleting joins markers', (assert) => {
   const done = assert.async();
@@ -130,7 +120,7 @@ test('selecting text across markers and deleting joins markers', (assert) => {
   Helpers.dom.triggerEvent(document, 'mouseup');
 
   setTimeout(() => {
-    clickToolbarButton(assert, 'bold');
+    Helpers.toolbar.clickButton(assert, 'bold');
 
     let firstTextNode = editorElement
                            .childNodes[0] // p
@@ -144,7 +134,7 @@ test('selecting text across markers and deleting joins markers', (assert) => {
     assert.equal(secondTextNode.textContent, 'ion', 'correct second text node');
     Helpers.dom.selectText('t sect', firstTextNode,
                            'ion',    secondTextNode);
-    Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+    Helpers.dom.triggerDelete(editor);
 
     assert.hasElement('p:contains(firs)', 'deletes across markers');
     assert.hasElement('strong:contains(rs)', 'maintains bold text');

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -54,3 +54,113 @@ test('selecting across sections is possible', (assert) => {
     done();
   });
 });
+
+test('selecting an entire section and deleting removes it', (assert) => {
+  const done = assert.async();
+
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  Helpers.dom.selectText('second section', editorElement);
+  Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+
+  assert.hasElement('p:contains(first section)');
+  assert.hasNoElement('p:contains(second section)', 'deletes contents of second section');
+  assert.equal($('#editor p').length, 2, 'still has 2 sections');
+
+  let textNode = editorElement
+                  .childNodes[1] // second section p
+                  .childNodes[0]; // textNode
+
+  assert.deepEqual(Helpers.dom.getCursorPosition(),
+                   {node: textNode, offset: 0});
+
+  done();
+});
+
+test('selecting text in a section and deleting deletes it', (assert) => {
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  Helpers.dom.selectText('cond sec', editorElement);
+  Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+
+  assert.hasElement('p:contains(first section)', 'first section unchanged');
+  assert.hasNoElement('p:contains(second section)', 'second section is no longer there');
+  assert.hasElement('p:contains(setion)', 'second section has correct text');
+
+  let textNode = $('p:contains(setion)')[0].childNodes[0];
+  assert.equal(textNode.textContent, 'se', 'precond - has correct text node');
+  let charOffset = 2; // after the 'e' in 'se'
+
+  assert.deepEqual(Helpers.dom.getCursorPosition(),
+                   {node: textNode, offset: charOffset});
+});
+
+test('selecting text across sections and deleting joins sections', (assert) => {
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  const firstSection = $('#editor p')[0],
+        secondSection = $('#editor p')[1];
+
+  Helpers.dom.selectText('t section', firstSection,
+                         'second s', secondSection);
+  Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+
+  assert.hasElement('p:contains(firsection)');
+  assert.hasNoElement('p:contains(first section)');
+  assert.hasNoElement('p:contains(second section)');
+  assert.equal($('#editor p').length, 1, 'only 1 section after deleting to join');
+});
+
+function getToolbarButton(assert, name) {
+  let btnSelector = `.ck-toolbar-btn[title="${name}"]`;
+  return assert.hasElement(btnSelector);
+}
+
+function clickToolbarButton(assert, name) {
+  const button = getToolbarButton(assert, name);
+  Helpers.dom.triggerEvent(button[0], 'click');
+}
+
+test('selecting text across markers and deleting joins markers', (assert) => {
+  const done = assert.async();
+
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  Helpers.dom.selectText('rst sect', editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    clickToolbarButton(assert, 'bold');
+
+    let firstTextNode = editorElement
+                           .childNodes[0] // p
+                           .childNodes[1] // b
+                           .childNodes[0]; // textNode containing "rst sect"
+    let secondTextNode = editorElement
+                             .childNodes[0] // p
+                             .childNodes[2]; // textNode containing "ion"
+
+    assert.equal(firstTextNode.textContent, 'rst sect', 'correct first text node');
+    assert.equal(secondTextNode.textContent, 'ion', 'correct second text node');
+    Helpers.dom.selectText('t sect', firstTextNode,
+                           'ion',    secondTextNode);
+    Helpers.dom.triggerKeyEvent(document, 'keydown', Helpers.dom.KEY_CODES.DELETE);
+
+    assert.hasElement('p:contains(firs)', 'deletes across markers');
+    assert.hasElement('strong:contains(rs)', 'maintains bold text');
+
+    firstTextNode = editorElement
+                      .childNodes[0] // p
+                      .childNodes[1] // b
+                      .childNodes[0]; // textNode now containing "rs"
+
+    assert.deepEqual(Helpers.dom.getCursorPosition(),
+                     {node: firstTextNode, offset: 2});
+
+    done();
+  });
+});
+
+// test selecting text across markers deletes intermediary markers
+// test selecting text that includes entire sections deletes the sections
+// test selecting text and hitting enter or keydown

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -3,6 +3,7 @@ const TEXT_NODE = 3;
 import { clearSelection } from 'content-kit-editor/utils/selection-utils';
 import { walkDOMUntil } from 'content-kit-editor/utils/dom-utils';
 import KEY_CODES from 'content-kit-editor/utils/keycodes';
+import isPhantom from './is-phantom';
 
 function selectRange(startNode, startOffset, endNode, endOffset) {
   clearSelection();
@@ -135,6 +136,16 @@ function getCursorPosition() {
   };
 }
 
+function triggerDelete(editor) {
+  if (isPhantom()) {
+    // simulate deletion
+    let event = { preventDefault() {} };
+    editor.handleDeletion(event);
+  } else {
+    triggerKeyEvent(document, 'keydown', KEY_CODES.DELETE);
+  }
+}
+
 const DOMHelper = {
   moveCursorTo,
   selectText,
@@ -144,7 +155,10 @@ const DOMHelper = {
   makeDOM,
   KEY_CODES,
   getCursorPosition,
-  getSelectedText
+  getSelectedText,
+  triggerDelete
 };
+
+export { triggerEvent };
 
 export default DOMHelper;

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -138,7 +138,7 @@ function getCursorPosition() {
 
 function triggerDelete(editor) {
   if (isPhantom()) {
-    // simulate deletion
+    // simulate deletion for phantomjs
     let event = { preventDefault() {} };
     editor.handleDeletion(event);
   } else {

--- a/tests/helpers/is-phantom.js
+++ b/tests/helpers/is-phantom.js
@@ -1,0 +1,3 @@
+export default () => {
+  return navigator.userAgent.indexOf('PhantomJS') !== -1;
+};

--- a/tests/helpers/skip-in-phantom.js
+++ b/tests/helpers/skip-in-phantom.js
@@ -1,8 +1,8 @@
 const { test } = QUnit;
+import isPhantom from './is-phantom';
 
 export default function(message, testFn) {
-  const isPhantom = navigator.userAgent.indexOf('PhantomJS') !== -1;
-  if (isPhantom) {
+  if (isPhantom()) {
     message = '[SKIPPED in PhantomJS] ' + message;
     testFn = (assert) => assert.ok(true);
   }

--- a/tests/helpers/toolbar.js
+++ b/tests/helpers/toolbar.js
@@ -1,0 +1,40 @@
+import { triggerEvent } from './dom';
+
+function getToolbarButton(assert, name) {
+  let btnSelector = `.ck-toolbar-btn[title="${name}"]`;
+  return assert.hasElement(btnSelector);
+}
+
+function assertVisible(assert) {
+  return assert.hasElement(`.ck-toolbar`);
+}
+
+function assertHidden(assert) {
+  return assert.hasNoElement(`.ck-toolbar`);
+}
+
+function clickButton(assert, name) {
+  const button = getToolbarButton(assert, name);
+  triggerEvent(button[0], 'click');
+}
+
+function assertActiveButton(assert, buttonTitle) {
+  const button = getToolbarButton(assert, buttonTitle);
+  assert.ok(button.is('.active'), `button ${buttonTitle} is active`);
+}
+
+function assertInactiveButton(assert, buttonTitle) {
+  const button = getToolbarButton(assert, buttonTitle);
+  assert.ok(!button.is('.active'), `button ${buttonTitle} is not active`);
+}
+
+const ToolbarHelpers = {
+  getToolbarButton,
+  assertVisible,
+  assertHidden,
+  assertActiveButton,
+  assertInactiveButton,
+  clickButton
+};
+
+export default ToolbarHelpers;

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -2,9 +2,11 @@ import registerAssertions from './helpers/assertions';
 registerAssertions();
 
 import DOMHelpers from './helpers/dom';
+import ToolbarHelpers from './helpers/toolbar';
 import skipInPhantom from './helpers/skip-in-phantom';
 
 export default {
   dom: DOMHelpers,
+  toolbar: ToolbarHelpers,
   skipInPhantom
 };


### PR DESCRIPTION
This adds `post#cutMarkers(markers)` and `editor#deleteSelection`.

Also adds `Helpers.toolbar` for sharing toolbar-related assertions in tests, and
`Helpers.dom.triggerDelete`, which detects phantom and simulates a delete (by calling `editor.handleDeletion`) — this allows some of the previous skipped-in-phantom tests to run in phantom, now.

Ready for review. I will start on the items below but make a separate PR for them. @mixonic lmk if you have feedback.

To do:
  * [ ] handle newlines when there is a selection (delete the selection first then apply the newline action) (#49)
  * [ ] handle keystrokes when there is a selection (contenteditable almost does this for us, but it inserts irrelevant spans to try to maintain visual styling — this should be handled semantically as well) (#50)