### PR TITLE
Ensure multiple markup applications are rendered appropriately

### DIFF
--- a/src/js/utils/linked-list.js
+++ b/src/js/utils/linked-list.js
@@ -19,6 +19,8 @@ export default class LinkedList {
     let nextItem = null;
     if (prevItem) {
       nextItem = prevItem.next;
+    } else {
+      nextItem = this.head;
     }
     this.insertBefore(item, nextItem);
   }

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -151,6 +151,31 @@ test('selecting text across markers and deleting joins markers', (assert) => {
   });
 });
 
+test('select text and apply markup multiple times', (assert) => {
+  const done = assert.async();
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  Helpers.dom.selectText('t sect', editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    Helpers.toolbar.clickButton(assert, 'bold');
+
+    Helpers.dom.selectText('fir', editorElement);
+    Helpers.dom.triggerEvent(document, 'mouseup');
+
+    setTimeout(() => {
+      Helpers.toolbar.clickButton(assert, 'bold');
+
+      assert.hasElement('p:contains(first section)', 'correct first section');
+      assert.hasElement('strong:contains(fir)', 'strong "fir"');
+      assert.hasElement('strong:contains(t sect)', 'strong "t sect"');
+
+      done();
+    });
+  });
+});
+
 // test selecting text across markers deletes intermediary markers
 // test selecting text that includes entire sections deletes the sections
 // test selecting text and hitting enter or keydown

--- a/tests/unit/utils/linked-list-test.js
+++ b/tests/unit/utils/linked-list-test.js
@@ -104,6 +104,28 @@ test(`#insertAfter a middle item`, (assert) => {
   assert.equal(itemThree.next, null, 'itemThree next is null');
 });
 
+test('#insertAfter null reference item prepends the item', (assert) => {
+  let list = new LinkedList();
+  let item1 = new LinkedItem();
+  let item2 = new LinkedItem();
+  list.append(item1);
+  list.insertAfter(item2, null);
+
+  assert.equal(list.head, item2, 'item2 is appended');
+  assert.equal(list.tail, item1, 'item1 is at tail');
+});
+
+test('#insertBefore null reference item appends the item', (assert) => {
+  let list = new LinkedList();
+  let item1 = new LinkedItem();
+  let item2 = new LinkedItem();
+  list.append(item1);
+  list.insertBefore(item2, null);
+
+  assert.equal(list.tail, item2, 'item2 is appended');
+  assert.equal(list.head, item1, 'item1 is at head');
+});
+
 test(`#remove an only item`, (assert) => {
   let list = new LinkedList();
   let item = new LinkedItem();


### PR DESCRIPTION
Fixes an issue where a renderNode gets out of sync with its element, causing a marker to be rendered to detached dom (aka disappearing).

To replicate:
  * select some text in a line, apply a markup (click toolbar "B")
  * select some other text closer to the start of the line, apply a markup (click toolbar "B")
  * the text up to and including the selected text is removed in the editor dom upon rerender

