### PR TITLE
Ensure that the editor triggers an update when clicking "heading"

### DIFF
--- a/src/js/commands/format-block.js
+++ b/src/js/commands/format-block.js
@@ -29,6 +29,7 @@ class FormatBlockCommand extends TextFormatCommand {
 
     editor.rerender();
     editor.selectSections(activeSections);
+    this.editor.didUpdate();
   }
 
   unexec() {
@@ -41,6 +42,7 @@ class FormatBlockCommand extends TextFormatCommand {
 
     editor.rerender();
     editor.selectSections(activeSections);
+    this.editor.didUpdate();
   }
 }
 

--- a/src/js/commands/image.js
+++ b/src/js/commands/image.js
@@ -17,6 +17,6 @@ export default class ImageCommand extends Command {
     sections.forEach(section => section.renderNode.scheduleForRemoval());
 
     this.editor.rerender();
-    this.editor.trigger('update');
+    this.editor.didUpdate();
   }
 }

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -71,6 +71,24 @@ test('highlight text, click "heading" button turns text into h2 header', (assert
   });
 });
 
+test('click heading button triggers update', (assert) => {
+  const done = assert.async();
+  const triggered = [];
+  const triggerFn = editor.trigger;
+  editor.trigger = (name, ...args) => {
+    triggered.push(name);
+    triggerFn.call(editor, name, ...args);
+  };
+
+  setTimeout(() => {
+    Helpers.toolbar.clickButton(assert, 'heading');
+    assert.ok(triggered.indexOf('update') !== -1,
+              'update was triggered');
+
+    done();
+  });
+});
+
 test('highlighting heading text activates toolbar button', (assert) => {
   const done = assert.async();
 


### PR DESCRIPTION
Adds an `editor.didUpdate` call to `FormatBlockCommand`

fixes #58