### PR TITLE
Ensure Marker#join returns a Marker with a builder

### DIFF
--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -82,7 +82,7 @@ const Marker = class Marker extends LinkedItem {
   }
 
   join(other) {
-    const joined = new Marker(this.value + other.value);
+    const joined = this.builder.createMarker(this.value + other.value);
     this.markups.forEach(m => joined.addMarkup(m));
     other.markups.forEach(m => joined.addMarkup(m));
 

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -73,6 +73,7 @@ test('a marker can be joined to another', (assert) => {
   m2.addMarkup(builder.createMarkup('i'));
 
   const m3 = m1.join(m2);
+  assert.equal(m3.builder, builder, 'joined marker also has builder');
   assert.equal(m3.value, 'hi there!');
   assert.ok(m3.hasMarkup('b'));
   assert.ok(m3.hasMarkup('i'));


### PR DESCRIPTION
Fixes a bug that can occur if you hit delete and join two markers or
two sections.