### PR TITLE
Use `isEmpty` prop instead of `empty()` method on marker and section

### DIFF
--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -26,7 +26,7 @@ const Marker = class Marker extends LinkedItem {
     return new this.constructor(this.value, clonedMarkups);
   }
 
-  empty() {
+  get isEmpty() {
     return this.length === 0;
   }
 

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -41,8 +41,8 @@ export default class Section extends LinkedItem {
     return this._tagName;
   }
 
-  isEmpty() {
-    return this.markers.length === 0;
+  get isEmpty() {
+    return this.markers.isEmpty;
   }
 
   setTagName(newTagName) {
@@ -64,7 +64,7 @@ export default class Section extends LinkedItem {
    * @return {Array} the new markers that replaced `marker`
    */
   splitMarker(marker, offset, endOffset=marker.length) {
-    const newMarkers = filter(marker.split(offset, endOffset), m => !m.empty());
+    const newMarkers = filter(marker.split(offset, endOffset), m => !m.isEmpty);
     this.markers.splice(marker, 1, newMarkers);
     return newMarkers;
   }
@@ -101,7 +101,7 @@ export default class Section extends LinkedItem {
    */
   coalesceMarkers() {
     forEach(this.markers, m => {
-      if (m.empty()) {
+      if (m.isEmpty) {
         this.markers.remove(m);
       }
     });

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -38,7 +38,7 @@ export default class Post {
 
     // add a blank marker to any sections that are now empty
     changedSections.forEach(section => {
-      if (section.isEmpty()) {
+      if (section.isEmpty) {
         section.markers.append(this.builder.createBlankMarker());
       }
     });

--- a/tests/unit/models/marker-test.js
+++ b/tests/unit/models/marker-test.js
@@ -89,7 +89,7 @@ test('#split splits a marker in 3 with blank markers when no endOffset is passed
 
   assert.equal(beforeMarker.value, 'hi th');
   assert.equal(afterMarkers[0].value, 'ere!');
-  assert.ok(afterMarkers[1].empty(), 'final split marker is empty');
+  assert.ok(afterMarkers[1].isEmpty, 'final split marker is empty');
 });
 
 test('#split splits a marker in 3 when endOffset is passed', (assert) => {
@@ -111,7 +111,7 @@ test('#split creates an initial empty marker if the offset is 0', (assert) => {
   const m = builder.createMarker('hi there!');
   const [beforeMarker, ...afterMarkers] = m.split(0);
   assert.equal(afterMarkers.length, 2, '2 after markers');
-  assert.ok(beforeMarker.empty(), 'beforeMarker is empty');
+  assert.ok(beforeMarker.isEmpty, 'beforeMarker is empty');
   assert.equal(afterMarkers[0].value, 'hi there!');
-  assert.ok(afterMarkers[1].empty(), 'final afterMarker is empty');
+  assert.ok(afterMarkers[1].isEmpty, 'final afterMarker is empty');
 });


### PR DESCRIPTION
Builds on #60, now there are no longer any usages of `empty()` as a method call