### PR TITLE
Ensure parsed mobiledocs have a blank marker

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -24,6 +24,7 @@ import EventEmitter from '../utils/event-emitter';
 
 import MobiledocParser from "../parsers/mobiledoc";
 import PostParser from '../parsers/post';
+import DOMParser from '../parsers/dom';
 import Renderer  from 'content-kit-editor/renderers/editor-dom';
 import {
   UNPRINTABLE_CHARACTER
@@ -279,7 +280,8 @@ class Editor {
   }
 
   parseModelFromDOM(element) {
-    this.post = this._parser.parse(element);
+    let parser = new DOMParser(this.builder);
+    this.post = parser.parse(element);
     this._renderTree = new RenderTree();
     let node = this._renderTree.buildRenderNode(this.post);
     this._renderTree.node = node;

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -154,6 +154,10 @@ NewHTMLParser.prototype = {
       parseMarkers(section, builder, sectionElement);
       break;
     }
+    if (section.markers.isEmpty) {
+      let marker = this.builder.createBlankMarker();
+      section.markers.append(marker);
+    }
     return section;
   },
   parse: function(postElement) {
@@ -174,6 +178,14 @@ NewHTMLParser.prototype = {
         }
       }
     }
+
+    if (post.sections.isEmpty) {
+      section = this.builder.createMarkupSection('p');
+      let marker = this.builder.createBlankMarker();
+      section.markers.append(marker);
+      post.sections.append(section);
+    }
+
     return post;
   }
 };

--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -21,6 +21,13 @@ export default class MobiledocParser {
     this.markerTypes = this.parseMarkerTypes(markerTypes);
     this.parseSections(sections, post);
 
+    if (post.sections.isEmpty) {
+      let section = this.builder.createMarkupSection('p');
+      let marker = this.builder.createBlankMarker();
+      section.markers.append(marker);
+      post.sections.append(section);
+    }
+
     return post;
   }
 
@@ -67,6 +74,10 @@ export default class MobiledocParser {
     const section = this.builder.createMarkupSection(tagName);
     post.sections.append(section);
     this.parseMarkers(markers, section);
+    if (section.markers.isEmpty) {
+      let marker = this.builder.createBlankMarker();
+      section.markers.append(marker);
+    }
   }
 
   parseMarkers(markers, section) {

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -25,6 +25,11 @@ module('Unit: Editor', {
 test('can create an editor via dom node reference', (assert) => {
   editor = new Editor(editorElement);
   assert.equal(editor.element, editorElement);
+  assert.ok(editor.post);
+  assert.equal(editor.post.sections.length, 1);
+  assert.equal(editor.post.sections.head.tagName, 'p');
+  assert.equal(editor.post.sections.head.markers.length, 1);
+  assert.equal(editor.post.sections.head.markers.head.value, '');
 });
 
 test('can create an editor via dom node reference from getElementById', (assert) => {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -26,6 +26,11 @@ module('Unit: DOMParser', {
 
 test('parse empty content', (assert) => {
   const post = parser.parse(buildDOM(''));
+  let section = builder.createMarkupSection('p');
+  expectedPost.sections.append(section);
+  let marker = builder.createMarker();
+  section.markers.append(marker);
+
   assert.deepEqual(post, expectedPost);
 });
 

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -25,6 +25,27 @@ test('#parse empty doc returns an empty post', (assert) => {
     version: MOBILEDOC_VERSION,
     sections: [[], []]
   };
+
+  let section = builder.createMarkupSection('P');
+  let marker  = builder.createBlankMarker();
+  section.markers.append(marker);
+  post.sections.append(section);
+  assert.deepEqual(parser.parse(mobiledoc),
+                   post);
+});
+
+test('#parse empty markup section returns an empty post', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [[], [
+      [1, 'h2', []]
+    ]]
+  };
+
+  let section = builder.createMarkupSection('h2');
+  let marker  = builder.createBlankMarker();
+  section.markers.append(marker);
+  post.sections.append(section);
   assert.deepEqual(parser.parse(mobiledoc),
                    post);
 });


### PR DESCRIPTION
This allows a valid mobiledoc with zero sections (or one section with zero markers) to be parsed into an abstract with a text prompt.

It does not address https://github.com/bustlelabs/content-kit-editor/issues/57, but a fix for that should be similar. Spiking on it now, will push here.