### PR TITLE
Handle a newline correctly when there is a non-collapsed selection

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -428,6 +428,10 @@ class Editor {
   }
 
   handleNewline(event) {
+    if (this.cursor.hasSelection()) {
+      this.handleDeletion(event);
+    }
+
     const {
       leftRenderNode,
       rightRenderNode,
@@ -438,7 +442,6 @@ class Editor {
     // or we have selected some non-marker thing like a card
     if (!leftRenderNode || !rightRenderNode) { return; }
 
-    // FIXME handle when the selection is not collapsed, this code assumes it is
     event.preventDefault();
 
     const markerRenderNode = leftRenderNode;

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -100,11 +100,10 @@ export default class Section extends LinkedItem {
    * Mutates this section's markers
    */
   coalesceMarkers() {
-    forEach(this.markers, m => {
-      if (m.isEmpty) {
-        this.markers.remove(m);
-      }
-    });
+    forEach(
+      filter(this.markers, m => m.isEmpty),
+      m => this.markers.remove(m)
+    );
     if (this.markers.isEmpty) {
       this.markers.append(this.builder.createBlankMarker());
     }

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -205,6 +205,31 @@ test('selecting text across markers deletes intermediary markers', (assert) => {
   });
 });
 
+test('selecting text across sections and hitting enter deletes and moves cursor to last selected section', (assert) => {
+  const done = assert.async();
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  let firstSection = $('#editor p:eq(0)')[0],
+      secondSection = $('#editor p:eq(1)')[0];
+
+  Helpers.dom.selectText(' section', firstSection,
+                         'second ', secondSection);
+
+  Helpers.dom.triggerEnter(editor);
+
+  setTimeout(() => {
+    assert.equal($('#editor p').length, 2, 'still 2 sections');
+    assert.equal($('#editor p:eq(0)').text(), 'first', 'correct text in 1st section');
+    assert.equal($('#editor p:eq(1)').text(), 'section', 'correct text in 2nd section');
+
+    let secondSectionTextNode = editor.element.childNodes[1].childNodes[0];
+    assert.deepEqual(Helpers.dom.getCursorPosition(),
+                    {node: secondSectionTextNode, offset: 0},
+                    'cursor is at start of second section');
+    done();
+  });
+});
+
 // test selecting text that includes entire sections deletes the sections
 // test selecting text across two types of sections and deleting
 // test selecting text and hitting enter or keydown

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -152,3 +152,29 @@ test('#splitMarker does not create an empty marker if offset=0', (assert) => {
   assert.equal(s.markers.head.value, 'hi ', 'original 1st marker unchanged');
   assert.equal(s.markers.tail.value, 'there!', 'original 2nd marker unchanged');
 });
+
+test('#coalesceMarkers removes empty markers', (assert) => {
+  const m1 = builder.createBlankMarker();
+  const m2 = builder.createBlankMarker();
+  const m3 = builder.createMarker('hello');
+  const s = builder.createMarkupSection('p', [m1,m2,m3]);
+
+  assert.equal(s.markers.length, 3, 'precond - correct # markers');
+
+  s.coalesceMarkers();
+  assert.equal(s.markers.length, 1, 'has 1 marker after coalescing');
+  assert.equal(s.markers.head, m3, 'has correct remaining marker');
+});
+
+test('#coalesceMarkers appends a single blank marker if all the markers were blank', (assert) => {
+  const m1 = builder.createBlankMarker();
+  const m2 = builder.createBlankMarker();
+  const s = builder.createMarkupSection('p', [m1,m2]);
+
+  assert.equal(s.markers.length, 2, 'precond - correct # markers');
+
+  s.coalesceMarkers();
+
+  assert.equal(s.markers.length, 1, 'has 1 marker after coalescing');
+  assert.ok(s.markers.head.isEmpty, 'remaining marker is empty');
+});


### PR DESCRIPTION
Changes `editor.handleNewline` to first call `handleDeletion` if there is a selection

fixes #49