### PR TITLE
Refactor some method into public postEditor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,33 @@ var editor = new ContentKit.Editor(element, options);
   Mobiledoc.
 * `editor.destroy()` - teardown the editor event listeners, free memory etc.
 
+### Programmatic Post Editing
+
+A major goal of Content-Kit is to allow complete customization of user
+interfaces using the editing surface. The programmatic editing API allows
+the creation of completely custom interfaces for buttons, hot-keys, and
+other interactions.
+
+To change the post in code, use the `editor.run` API. For example, the
+following usage would mark currently selected text as bold:
+
+```js
+let strongMarkup = editor.builder.createMarkup('strong');
+let markerRange = editor.cursor.offsets;
+editor.run((postEditor) => {
+  postEditor.applyMarkupToMarkers(markerRange, strongMarkup);
+});
+```
+
+It is important that you make changes to posts, sections, and markers through
+the `run` and `postEditor` API. This API allows Content-Kit to conserve
+and better understand changes being made to the post.
+
+For more details on the API of `postEditor`, see the [API documentation](https://github.com/mixonic/content-kit-editor/blob/master/src/js/editor/post.js).
+
+For more details on the API for the builder, required to create new sections
+and markers, see the [builder API](https://github.com/mixonic/content-kit-editor/blob/master/src/js/models/post-node-builder.js).
+
 ### Contributing
 
 Fork the repo, write a test, make a change, open a PR.

--- a/src/js/commands/bold.js
+++ b/src/js/commands/bold.js
@@ -15,6 +15,9 @@ export default class BoldCommand extends TextFormatCommand {
   }
   exec() {
     let markerRange = this.editor.cursor.offsets;
+    if (!markerRange.leftRenderNode || !markerRange.rightRenderNode) {
+      return;
+    }
     let markers = this.editor.run((postEditor) => {
       return postEditor.applyMarkupToMarkers(markerRange, this.markup);
     });

--- a/src/js/commands/bold.js
+++ b/src/js/commands/bold.js
@@ -14,10 +14,18 @@ export default class BoldCommand extends TextFormatCommand {
     this.markup = builder.createMarkup('strong');
   }
   exec() {
-    this.editor.applyMarkupToSelection(this.markup);
+    let markerRange = this.editor.cursor.offsets;
+    let markers = this.editor.run((postEditor) => {
+      return postEditor.applyMarkupToMarkers(markerRange, this.markup);
+    });
+    this.editor.selectMarkers(markers);
   }
   unexec() {
-    this.editor.removeMarkupFromSelection(this.markup);
+    let markerRange = this.editor.cursor.offsets;
+    let markers = this.editor.run((postEditor) => {
+      return postEditor.removeMarkupFromMarkers(markerRange, this.markup);
+    });
+    this.editor.selectMarkers(markers);
   }
   isActive() {
     return any(this.editor.activeMarkers, m => m.hasMarkup(this.markup));

--- a/src/js/commands/image.js
+++ b/src/js/commands/image.js
@@ -9,14 +9,16 @@ export default class ImageCommand extends Command {
   }
 
   exec() {
-    let {post, builder} = this.editor;
-    let sections = this.editor.activeSections;
-    let lastSection = sections[sections.length - 1];
-    let section = builder.createCardSection('image');
-    post.sections.insertAfter(section, lastSection);
-    sections.forEach(section => section.renderNode.scheduleForRemoval());
+    let {headMarker} = this.editor.cursor.offsets;
+    let beforeSection = headMarker.section;
+    let afterSection = beforeSection.next;
+    let section = this.editor.builder.createCardSection('image');
 
-    this.editor.rerender();
-    this.editor.didUpdate();
+    this.editor.run((postEditor) => {
+      if (beforeSection.isBlank) {
+        postEditor.removeSection(beforeSection);
+      }
+      postEditor.insertSectionBefore(section, afterSection);
+    });
   }
 }

--- a/src/js/commands/italic.js
+++ b/src/js/commands/italic.js
@@ -15,6 +15,9 @@ export default class ItalicCommand extends TextFormatCommand {
   }
   exec() {
     let markerRange = this.editor.cursor.offsets;
+    if (!markerRange.leftRenderNode || !markerRange.rightRenderNode) {
+      return;
+    }
     let markers = this.editor.run((postEditor) => {
       return postEditor.applyMarkupToMarkers(markerRange, this.markup);
     });

--- a/src/js/commands/italic.js
+++ b/src/js/commands/italic.js
@@ -14,10 +14,18 @@ export default class ItalicCommand extends TextFormatCommand {
     this.markup = builder.createMarkup('em');
   }
   exec() {
-    this.editor.applyMarkupToSelection(this.markup);
+    let markerRange = this.editor.cursor.offsets;
+    let markers = this.editor.run((postEditor) => {
+      return postEditor.applyMarkupToMarkers(markerRange, this.markup);
+    });
+    this.editor.selectMarkers(markers);
   }
   unexec() {
-    this.editor.removeMarkupFromSelection(this.markup);
+    let markerRange = this.editor.cursor.offsets;
+    let markers = this.editor.run((postEditor) => {
+      return postEditor.removeMarkupFromMarkers(markerRange, this.markup);
+    });
+    this.editor.selectMarkers(markers);
   }
   isActive() {
     return any(this.editor.activeMarkers, m => m.hasMarkup(this.markup));

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -276,12 +276,6 @@ class Editor {
     this._views.push(view);
   }
 
-  loadModel(post) {
-    this.post = post;
-    this.rerender();
-    this.trigger('update');
-  }
-
   parseModelFromDOM(element) {
     let parser = new DOMParser(this.builder);
     this.post = parser.parse(element);

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -1,6 +1,7 @@
 import TextFormatToolbar  from '../views/text-format-toolbar';
 import Tooltip from '../views/tooltip';
 import EmbedIntent from '../views/embed-intent';
+import PostEditor from './post';
 
 import ReversibleToolbarButton from '../views/reversible-toolbar-button';
 import BoldCommand from '../commands/bold';
@@ -17,9 +18,6 @@ import CardCommand from '../commands/card';
 import ImageCard from '../cards/image';
 
 import Key from '../utils/key';
-import {
-  getSelectionBlockElement
-} from '../utils/selection-utils';
 import EventEmitter from '../utils/event-emitter';
 
 import MobiledocParser from "../parsers/mobiledoc";
@@ -32,7 +30,7 @@ import {
 import RenderTree from 'content-kit-editor/models/render-tree';
 import MobiledocRenderer from '../renderers/mobiledoc';
 
-import { toArray, mergeWithOptions } from 'content-kit-utils';
+import { mergeWithOptions } from 'content-kit-utils';
 import {
   clearChildNodes,
   addClassName
@@ -44,7 +42,6 @@ import { getData, setData } from '../utils/element-utils';
 import mixin from '../utils/mixin';
 import EventListenerMixin from '../utils/event-listener';
 import Cursor from '../models/cursor';
-import { MARKUP_SECTION_TYPE } from '../models/markup-section';
 import PostNodeBuilder from '../models/post-node-builder';
 
 export const EDITOR_ELEMENT_CLASS_NAME = 'ck-editor';
@@ -150,10 +147,13 @@ function bindKeyListeners(editor) {
       editor.handleDeletion(event);
       event.preventDefault();
     } else if (key.isEnter()) {
-        editor.handleNewline(event);
+      editor.handleNewline(event);
     } else if (key.isPrintable()) {
       if (editor.cursor.hasSelection()) {
-        editor.deleteSelection(event, {preventDefault:false});
+        let result = editor.run((postEditor) => {
+          return postEditor.deleteRange(editor.cursor.offsets);
+        });
+        editor.cursor.moveToMarker(result.currentMarker, result.currentOffset);
       }
     }
   });
@@ -311,124 +311,21 @@ class Editor {
     this._renderer.render(this._renderTree);
   }
 
-  deleteSelection(event, options={preventDefault:true}) {
-    if (options.preventDefault) {
-      event.preventDefault();
-    }
-
-    // types of selection deletion:
-    //   * a selection starts at the beginning of a section
-    //     -- cursor should end up at the beginning of that section
-    //     -- if the section not longer has markers, add a blank one for the cursor to focus on
-    //   * a selection is entirely within a section
-    //     -- split the markers with the selection, remove those new markers from their section
-    //     -- cursor goes at end of the marker before the selection start, or if the
-    //     -- selection was at the start of the section, cursor goes at section start
-    //   * a selection crosses multiple sections
-    //     -- remove all the sections that are between (exclusive ) selection start and end
-    //     -- join the start and end sections
-    //     -- mark the end section for removal
-    //     -- cursor goes at end of marker before the selection start
-
-    const markers = this.splitMarkersFromSelection();
-
-    const {changedSections, removedSections, currentMarker, currentOffset} = this.post.cutMarkers(markers);
-
-    changedSections.forEach(section => section.renderNode.markDirty());
-    removedSections.forEach(section => section.renderNode.scheduleForRemoval());
-
-    this.rerender();
-
-    let currentTextNode = currentMarker.renderNode.element;
-    this.cursor.moveToNode(currentTextNode, currentOffset);
-
-    this.trigger('update');
-  }
-
-  // FIXME ensure we handle deletion when there is a selection
   handleDeletion(event) {
-    let {
-      leftRenderNode,
-      leftOffset
-    } = this.cursor.offsets;
+    event.preventDefault();
 
-    // need to handle these cases:
-    // when cursor is:
-    //   * A in the middle of a marker -- just delete the character
-    //   * B offset is 0 and there is a previous marker
-    //     * delete last char of previous marker
-    //   * C offset is 0 and there is no previous marker
-    //     * join this section with previous section
-
-    if (this.cursor.hasSelection()) {
-      this.deleteSelection(event);
-      return;
-    }
-
-    const currentMarker = leftRenderNode.postNode;
-    let nextCursorMarker = currentMarker;
-    let nextCursorOffset = leftOffset - 1;
-
-    // A: in the middle of a marker
-    if (leftOffset !== 0) {
-      currentMarker.deleteValueAtOffset(leftOffset-1);
-      if (currentMarker.length === 0 && currentMarker.section.markers.length > 1) {
-        leftRenderNode.scheduleForRemoval();
-
-        let isFirstRenderNode = leftRenderNode === leftRenderNode.parent.childNodes.head;
-        if (isFirstRenderNode) {
-          // move cursor to start of next node
-          nextCursorMarker = leftRenderNode.next.postNode;
-          nextCursorOffset = 0;
-        } else {
-          // move cursor to end of prev node
-          nextCursorMarker = leftRenderNode.prev.postNode;
-          nextCursorOffset = leftRenderNode.prev.postNode.length;
-        }
+    this.run((postEditor) => {
+      if (this.cursor.hasSelection()) {
+        postEditor.deleteRange(this.cursor.offsets);
       } else {
-        leftRenderNode.markDirty();
+        let {
+          headMarker: marker,
+          headOffset: offset
+        } = this.cursor.offsets;
+        // FIXME: perhaps this should accept this.cursor.offsets?
+        postEditor.deleteCharAt(marker, offset-1);
       }
-    } else {
-      let currentSection = currentMarker.section;
-      let previousMarker = currentMarker.prev;
-      if (previousMarker) { // (B)
-        let markerLength = previousMarker.length;
-        previousMarker.deleteValueAtOffset(markerLength - 1);
-      } else { // (C)
-        // possible previous sections:
-        //   * none -- do nothing
-        //   * markup section -- join to it
-        //   * non-markup section (card) -- select it? delete it?
-        let previousSection = currentSection.prev;
-        if (previousSection) {
-          let isMarkupSection = previousSection.type === MARKUP_SECTION_TYPE;
-
-          if (isMarkupSection) {
-            let lastPreviousMarker = previousSection.markers.tail;
-            previousSection.join(currentSection);
-            previousSection.renderNode.markDirty();
-            currentSection.renderNode.scheduleForRemoval();
-
-            nextCursorMarker = lastPreviousMarker.next;
-            nextCursorOffset = 0;
-          /*
-          } else {
-            // card section: ??
-          */
-          }
-        } else { // no previous section -- do nothing
-          nextCursorMarker = currentMarker;
-          nextCursorOffset = 0;
-        }
-      }
-    }
-
-    this.rerender();
-
-    this.cursor.moveToNode(nextCursorMarker.renderNode.element,
-                           nextCursorOffset);
-
-    this.trigger('update');
+    });
   }
 
   handleNewline(event) {
@@ -499,57 +396,18 @@ class Editor {
     this.hasSelection();
   }
 
-  /*
-   * @return {Array} of markers that are "inside the split"
-   */
-  splitMarkersFromSelection() {
-    const {
-      startMarker,
-      leftOffset:startMarkerOffset,
-      endMarker,
-      rightOffset:endMarkerOffset,
-      startSection,
-      endSection
-    } = this.cursor.offsets;
-
-    let selectedMarkers = [];
-
-    startMarker.renderNode.scheduleForRemoval();
-    endMarker.renderNode.scheduleForRemoval();
-
-    if (startMarker === endMarker) {
-      let newMarkers = startSection.splitMarker(
-        startMarker, startMarkerOffset, endMarkerOffset
-      );
-      selectedMarkers = this.markersInOffset(newMarkers, startMarkerOffset, endMarkerOffset);
-    } else {
-      let newStartMarkers = startSection.splitMarker(startMarker, startMarkerOffset);
-      let selectedStartMarkers = this.markersInOffset(newStartMarkers, startMarkerOffset);
-
-      let newEndMarkers = endSection.splitMarker(endMarker, endMarkerOffset);
-      let selectedEndMarkers = this.markersInOffset(newEndMarkers, 0, endMarkerOffset);
-
-      let newStartMarker = selectedStartMarkers[0],
-          newEndMarker = selectedEndMarkers[selectedEndMarkers.length - 1];
-
-      this.post.markersFrom(newStartMarker, newEndMarker, m => selectedMarkers.push(m));
-    }
-
-    return selectedMarkers;
-  }
-
-  markersInOffset(markers, startOffset, endOffset) {
+  markersInRange({headMarker, headOffset, tailMarker, tailOffset}) {
     let offset = 0;
     let foundMarkers = [];
-    let toEnd = endOffset === undefined;
-    if (toEnd) { endOffset = 0; }
+    let toEnd = tailOffset === undefined;
+    if (toEnd) { tailOffset = 0; }
 
-    markers.forEach(marker => {
+    this.post.markersFrom(headMarker, tailMarker, marker => {
       if (toEnd) {
-        endOffset += marker.length;
+        tailOffset += marker.length;
       }
 
-      if (offset >= startOffset && offset < endOffset) {
+      if (offset >= headOffset && offset < tailOffset) {
         foundMarkers.push(marker);
       }
 
@@ -559,30 +417,6 @@ class Editor {
     return foundMarkers;
   }
 
-  applyMarkupToSelection(markup) {
-    const markers = this.splitMarkersFromSelection();
-    markers.forEach(marker => {
-      marker.addMarkup(markup);
-      marker.section.renderNode.markDirty();
-    });
-
-    this.rerender();
-    this.selectMarkers(markers);
-    this.didUpdate();
-  }
-
-  removeMarkupFromSelection(markup) {
-    const markers = this.splitMarkersFromSelection();
-    markers.forEach(marker => {
-      marker.removeMarkup(markup);
-      marker.section.renderNode.markDirty();
-    });
-
-    this.rerender();
-    this.selectMarkers(markers);
-    this.didUpdate();
-  }
-
   selectMarkers(markers) {
     this.cursor.selectMarkers(markers);
     this.hasSelection();
@@ -590,12 +424,6 @@ class Editor {
 
   get cursor() {
     return new Cursor(this);
-  }
-
-  getCurrentBlockIndex() {
-    var selectionEl = this.element || getSelectionBlockElement();
-    var blockElements = toArray(this.element.children);
-    return blockElements.indexOf(selectionEl);
   }
 
   applyClassName(className) {
@@ -725,10 +553,6 @@ class Editor {
     }
   }
 
-  get cursorSelection() {
-    return this.cursor.cursorSelection;
-  }
-
   /*
    * Returns the active sections. If the cursor selection is collapsed this will be
    * an array of 1 item. Else will return an array containing each section that is either
@@ -804,6 +628,13 @@ class Editor {
   destroy() {
     this.removeAllEventListeners();
     this.removeAllViews();
+  }
+
+  run(callback) {
+    let postEditor = new PostEditor(this);
+    let result = callback(postEditor);
+    postEditor.complete();
+    return result;
   }
 }
 

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -607,6 +607,32 @@ class Editor {
     this.removeAllViews();
   }
 
+  /**
+   * Run a new post editing session. Yields a block with a new `postEditor`
+   * instance. This instance can be used to interact with the post abstract,
+   * and defers rendering until the end of all changes.
+   *
+   * Usage:
+   *
+   *     let markerRange = this.cursor.offsets;
+   *     editor.run((postEditor) => {
+   *       postEditor.deleteRange(markerRange);
+   *       // editing surface not updated yet
+   *       postEditor.schedule(() => {
+   *         console.log('logs during rerender flush');
+   *       });
+   *       // logging not yet flushed
+   *     });
+   *     // editing surface now updated.
+   *     // logging now flushed
+   *
+   * The return value of `run` is whatever was returned from the callback.
+   *
+   * @method run
+   * @param {Function} callback Function to handle post editing with, provided the `postEditor` as an argument.
+   * @return {} Whatever the return value of `callback` is.
+   * @public
+   */
   run(callback) {
     let postEditor = new PostEditor(this);
     let result = callback(postEditor);

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -615,16 +615,6 @@ class Editor {
     this._views = [];
   }
 
-  insertSectionAtCursor(newSection) {
-    let newRenderNode = this._renderTree.buildRenderNode(newSection);
-    let renderNodes = this.cursor.activeSections.map(s => s.renderNode);
-    let lastRenderNode = renderNodes[renderNodes.length-1];
-    lastRenderNode.parent.childNodes.insertAfter(newRenderNode, lastRenderNode);
-    this.post.sections.insertAfter(newSection, lastRenderNode.postNode);
-    renderNodes.forEach(renderNode => renderNode.scheduleForRemoval());
-    this.trigger('update');
-  }
-
   destroy() {
     this.removeAllEventListeners();
     this.removeAllViews();

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -206,6 +206,20 @@ class PostEditor {
     return markers;
   }
 
+  insertSectionBefore(section, beforeSection) {
+    this.editor.post.sections.insertBefore(section, beforeSection);
+    this.editor.post.renderNode.markDirty();
+
+    this.rerender();
+    this.didUpdate();
+  }
+
+  removeSection(section) {
+    section.renderNode.scheduleForRemoval();
+
+    this.rerender();
+    this.didUpdate();
+  }
 
   /**
    * A method for adding work the deferred queue

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -35,8 +35,8 @@ class PostEditor {
     changedSections.forEach(section => section.renderNode.markDirty());
     removedSections.forEach(section => section.renderNode.scheduleForRemoval());
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
 
     return {
       currentMarker,
@@ -113,8 +113,8 @@ class PostEditor {
       }
     }
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
 
     return {
       currentMarker: nextCursorMarker,
@@ -171,8 +171,8 @@ class PostEditor {
       });
     }
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
 
     return selectedMarkers;
   }
@@ -195,8 +195,8 @@ class PostEditor {
     post.sections.insertAfter(afterSection, beforeSection);
     post.renderNode.markDirty();
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
 
     return [beforeSection, afterSection];
   }
@@ -208,8 +208,8 @@ class PostEditor {
       marker.section.renderNode.markDirty();
     });
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
 
     return markers;
   }
@@ -221,8 +221,8 @@ class PostEditor {
       marker.section.renderNode.markDirty();
     });
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
 
     return markers;
   }
@@ -231,15 +231,15 @@ class PostEditor {
     this.editor.post.sections.insertBefore(section, beforeSection);
     this.editor.post.renderNode.markDirty();
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
   }
 
   removeSection(section) {
     section.renderNode.scheduleForRemoval();
 
-    this.rerender();
-    this.didUpdate();
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
   }
 
   /**
@@ -257,7 +257,7 @@ class PostEditor {
    * Add a rerender job to the queue
    *
    */
-  rerender() {
+  scheduleRerender() {
     this.schedule(() => {
       if (!this._didRerender) {
         this._didRerender = true;
@@ -270,7 +270,7 @@ class PostEditor {
    * Add an update notice job to the queue
    *
    */
-  didUpdate() {
+  scheduleDidUpdate() {
     this.schedule(() => {
       if (!this._didUpdate) {
         this._didUpdate = true;

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1,0 +1,262 @@
+import { MARKUP_SECTION_TYPE } from '../models/markup-section';
+class PostEditor {
+  constructor(editor) {
+    this.editor = editor;
+    this._completionWorkQueue = [];
+    this._didRerender = false;
+    this._didUpdate = false;
+    this._didComplete = false;
+  }
+
+  // types of selection deletion:
+  //   * a selection starts at the beginning of a section
+  //     -- cursor should end up at the beginning of that section
+  //     -- if the section not longer has markers, add a blank one for the cursor to focus on
+  //   * a selection is entirely within a section
+  //     -- split the markers with the selection, remove those new markers from their section
+  //     -- cursor goes at end of the marker before the selection start, or if the
+  //     -- selection was at the start of the section, cursor goes at section start
+  //   * a selection crosses multiple sections
+  //     -- remove all the sections that are between (exclusive ) selection start and end
+  //     -- join the start and end sections
+  //     -- mark the end section for removal
+  //     -- cursor goes at end of marker before the selection start
+  deleteRange(rangeMarkers) {
+    // rangeMarkers should be akin to this.cursor.offset
+    const markers = this.splitMarkers(rangeMarkers);
+
+    const {
+      changedSections,
+      removedSections,
+      currentMarker,
+      currentOffset
+    } = this.editor.post.cutMarkers(markers);
+
+    changedSections.forEach(section => section.renderNode.markDirty());
+    removedSections.forEach(section => section.renderNode.scheduleForRemoval());
+
+    this.didUpdate();
+    this.rerender();
+    this.schedule(() => {
+      // FIXME the cursor API should accept markers, not elements. Or there
+      // should be a proxy method on editor
+      let currentTextNode = currentMarker.renderNode.element;
+      this.editor.cursor.moveToNode(currentTextNode, currentOffset);
+    });
+  }
+
+  // need to handle these cases:
+  // when cursor is:
+  //   * A in the middle of a marker -- just delete the character
+  //   * B offset is 0 and there is a previous marker
+  //     * delete last char of previous marker
+  //   * C offset is 0 and there is no previous marker
+  //     * join this section with previous section
+  deleteCharAt(marker, offset) {
+    const currentMarker = marker;
+    let nextCursorMarker = currentMarker;
+    let nextCursorOffset = offset;
+    let renderNode = marker.renderNode;
+
+    // A: in the middle of a marker
+    if (offset >= 0) {
+      currentMarker.deleteValueAtOffset(offset);
+      if (currentMarker.length === 0 && currentMarker.section.markers.length > 1) {
+        if (marker.renderNode) {
+          marker.renderNode.scheduleForRemoval();
+        }
+
+        let isFirstRenderNode = renderNode === renderNode.parent.childNodes.head;
+        if (isFirstRenderNode) {
+          // move cursor to start of next node
+          nextCursorMarker = renderNode.next.postNode;
+          nextCursorOffset = 0;
+        } else {
+          // move cursor to end of prev node
+          nextCursorMarker = renderNode.prev.postNode;
+          nextCursorOffset = renderNode.prev.postNode.length;
+        }
+      } else {
+        renderNode.markDirty();
+      }
+    } else {
+      let currentSection = currentMarker.section;
+      let previousMarker = currentMarker.prev;
+      if (previousMarker) { // (B)
+        let markerLength = previousMarker.length;
+        previousMarker.deleteValueAtOffset(markerLength - 1);
+      } else { // (C)
+        // possible previous sections:
+        //   * none -- do nothing
+        //   * markup section -- join to it
+        //   * non-markup section (card) -- select it? delete it?
+        let previousSection = currentSection.prev;
+        if (previousSection) {
+          let isMarkupSection = previousSection.type === MARKUP_SECTION_TYPE;
+
+          if (isMarkupSection) {
+            let lastPreviousMarker = previousSection.markers.tail;
+            previousSection.join(currentSection);
+            previousSection.renderNode.markDirty();
+            currentSection.renderNode.scheduleForRemoval();
+
+            nextCursorMarker = lastPreviousMarker.next;
+            nextCursorOffset = 0;
+          /*
+          } else {
+            // card section: ??
+          */
+          }
+        } else { // no previous section -- do nothing
+          nextCursorMarker = currentMarker;
+          nextCursorOffset = 0;
+        }
+      }
+    }
+
+    this.didUpdate();
+    this.rerender();
+    this.schedule(() => {
+      let nextElement = nextCursorMarker.renderNode.element;
+      this.editor.cursor.moveToNode(
+        nextElement,
+        nextCursorOffset
+      );
+    });
+  }
+
+  /*
+   * @return {Array} of markers that are "inside the split"
+   */
+  splitMarkers({headMarker, headOffset, tailMarker, tailOffset}) {
+    let selectedMarkers = [];
+
+    let headSection = headMarker.section;
+    let tailSection = tailMarker.section;
+
+    // These render will be removed by the split functions. Mark them
+    // for removal before doing that. FIXME this seems prime for
+    // refactoring onto the postEditor as a split function
+    headMarker.renderNode.scheduleForRemoval();
+    headMarker.renderNode.scheduleForRemoval();
+    headMarker.section.renderNode.markDirty();
+    headMarker.section.renderNode.markDirty();
+
+    if (headMarker === tailMarker) {
+      let markers = headSection.splitMarker(headMarker, headOffset, tailOffset);
+      selectedMarkers = this.editor.markersInRange({
+        headMarker: markers[0],
+        tailMarker: markers[markers.length-1],
+        headOffset,
+        tailOffset
+      });
+    } else {
+      let newHeadMarkers = headSection.splitMarker(headMarker, headOffset);
+      let selectedHeadMarkers = this.editor.markersInRange({
+        headMarker: newHeadMarkers[0],
+        tailMarker: newHeadMarkers[newHeadMarkers.length-1],
+        headOffset
+      });
+
+      let newTailMarkers = tailSection.splitMarker(tailMarker, tailOffset);
+      let selectedTailMarkers = this.editor.markersInRange({
+        headMarker: newTailMarkers[0],
+        tailMarker: newTailMarkers[newTailMarkers.length-1],
+        headOffset: 0,
+        tailOffset
+      });
+
+      let newHeadMarker = selectedHeadMarkers[0],
+          newTailMarker = selectedTailMarkers[selectedTailMarkers.length - 1];
+
+      this.editor.post.markersFrom(newHeadMarker, newTailMarker, m => {
+        selectedMarkers.push(m);
+      });
+    }
+
+    this.didUpdate();
+    this.rerender();
+
+    return selectedMarkers;
+  }
+
+  applyMarkupToMarkers(markerRange, markup) {
+    const markers = this.splitMarkers(markerRange);
+    markers.forEach(marker => {
+      marker.addMarkup(markup);
+      marker.section.renderNode.markDirty();
+    });
+
+    this.rerender();
+    this.didUpdate();
+
+    return markers;
+  }
+
+  removeMarkupFromMarkers(markerRange, markup) {
+    const markers = this.splitMarkers(markerRange);
+    markers.forEach(marker => {
+      marker.removeMarkup(markup);
+      marker.section.renderNode.markDirty();
+    });
+
+    this.rerender();
+    this.didUpdate();
+
+    return markers;
+  }
+
+
+  /**
+   * A method for adding work the deferred queue
+   *
+   */
+  schedule(callback) {
+    if (this._didComplete) {
+      throw new Error('Work can only be scheduled before a post edit has completed');
+    }
+    this._completionWorkQueue.push(callback);
+  }
+
+  /**
+   * Add a rerender job to the queue
+   *
+   */
+  rerender() {
+    this.schedule(() => {
+      if (!this._didRerender) {
+        this._didRerender = true;
+        this.editor.rerender();
+      }
+    });
+  }
+
+  /**
+   * Add an update notice job to the queue
+   *
+   */
+  didUpdate() {
+    this.schedule(() => {
+      if (!this._didUpdate) {
+        this._didUpdate = true;
+        this.editor.didUpdate();
+      }
+    });
+  }
+
+  /**
+   * Flush the work queue
+   *
+   */
+  complete() {
+    if (this._didComplete) {
+      throw new Error('Post editing can only be completed once');
+    }
+    this._didComplete = true;
+    this._completionWorkQueue.forEach(callback => {
+      callback();
+    });
+  }
+}
+
+export default PostEditor;

--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -129,16 +129,16 @@ export default class Cursor {
   moveToSection(section) {
     const marker = section.markers.head;
     if (!marker) { throw new Error('Cannot move cursor to section without a marker'); }
-    const markerElement = marker.renderNode.element;
+    this.moveToMarker(marker);
+  }
 
-    let r = document.createRange();
-    r.selectNode(markerElement);
-    r.collapse(true);
-    const selection = this.selection;
-    if (selection.rangeCount > 0) {
-      selection.removeAllRanges();
-    }
-    selection.addRange(r);
+  // moves cursor to marker
+  moveToMarker(headMarker, headOffset=0, tailMarker=headMarker, tailOffset=headOffset) {
+    if (!headMarker) { throw new Error('Cannot move cursor to section without a marker'); }
+    const headElement = headMarker.renderNode.element;
+    const tailElement = tailMarker.renderNode.element;
+
+    this.moveToNode(headElement, headOffset, tailElement, tailOffset);
   }
 
   selectSections(sections) {

--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -95,7 +95,13 @@ export default class Cursor {
       startMarker,
       endMarker,
       startSection,
-      endSection
+      endSection,
+
+      // FIXME: this should become the public API
+      headMarker: startMarker,
+      tailMarker: endMarker,
+      headOffset: leftOffset,
+      tailOffset: rightOffset
     };
   }
 

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -41,8 +41,14 @@ export default class Section extends LinkedItem {
     return this._tagName;
   }
 
-  get isEmpty() {
-    return this.markers.isEmpty;
+  get isBlank() {
+    if (!this.markers.length) {
+      return true;
+    }
+    let markerWithLength = this.markers.detect((marker) => {
+      return !!marker.length;
+    });
+    return !markerWithLength;
   }
 
   setTagName(newTagName) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -38,7 +38,7 @@ export default class Post {
 
     // add a blank marker to any sections that are now empty
     changedSections.forEach(section => {
-      if (section.isEmpty) {
+      if (section.markers.isEmpty) {
         section.markers.append(this.builder.createBlankMarker());
       }
     });

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -205,6 +205,37 @@ test('selecting text across markers deletes intermediary markers', (assert) => {
   });
 });
 
+test('selecting text across markers preserves node after', (assert) => {
+  const done = assert.async();
+  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+
+  Helpers.dom.selectText('rst sec', editorElement);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    Helpers.toolbar.clickButton(assert, 'bold');
+
+    const textNode1 = editorElement.childNodes[0].childNodes[0],
+          textNode2 = editorElement.childNodes[0].childNodes[1];
+    Helpers.dom.selectText('i', textNode1,
+                           'sec', textNode2);
+    Helpers.dom.triggerEvent(document, 'mouseup');
+
+    setTimeout(() => {
+      Helpers.dom.triggerDelete(editor);
+
+      assert.deepEqual(
+        editorElement.childNodes[0].innerHTML, 'ftion',
+        'has remaining first section'
+      );
+      assert.deepEqual(Helpers.dom.getCursorPosition(),
+                       {node: editorElement.childNodes[0].childNodes[0],
+                         offset: 1});
+      done();
+    });
+  });
+});
+
 test('selecting text across sections and hitting enter deletes and moves cursor to last selected section', (assert) => {
   const done = assert.async();
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -149,3 +149,21 @@ test('#coalesceMarkers appends a single blank marker if all the markers were bla
   assert.equal(s.markers.length, 1, 'has 1 marker after coalescing');
   assert.ok(s.markers.head.isEmpty, 'remaining marker is empty');
 });
+
+test('#isBlank returns true if the text length is zero for two markers', (assert) => {
+  const m1 = builder.createBlankMarker();
+  const m2 = builder.createBlankMarker();
+  const s = builder.createMarkupSection('p', [m1,m2]);
+  assert.ok(s.isBlank, 'section with two blank markers is blank');
+});
+
+test('#isBlank returns true if there are no markers', (assert) => {
+  const s = builder.createMarkupSection('p');
+  assert.ok(s.isBlank, 'section with no markers is blank');
+});
+
+test('#isBlank returns false if there is a marker with length', (assert) => {
+  const m = builder.createMarker('a');
+  const s = builder.createMarkupSection('p', [m]);
+  assert.ok(!s.isBlank, 'section with marker is not blank');
+});


### PR DESCRIPTION
This begins the exposure of a public API programmatically interacting with the editor. For example:

```js
let editor = new ContentKit.Editor(someElement);

$('button').append(document.body).on('click', () => {

  let markerRange = editor.cursor.offsets;
  let markup = editor.builder.createMarkup('strong');
  editor.run((postEditor) => {
    postEditor.removeMarkupFromMarkers(markerRange, markup);
  });

});
```

While the editor and the cursor may create post abstract objects or read data about the current state of the editor, any modifications must be make through the `postEditor` interface. The runloop of the `postEditor` ensures that no matter what operations are performed only a single render and update are performed.

TODO:
 
* [x] On the `postEditor`, `this.rerender()` should be `this.scheduleRerender()`. Likewise for `didUpdate`
* [x] Docs
* [x] The internals of `handleNewline` must be migrated to `postEditor`
* [ ] ~~Operations during `reparse` must move to the `postEditor`~~ actually, reparse should be going away now that we control delete/enter. Should discuss with @bantic.
* [ ] ~~`loadModel` should become part of the editor~~ dropped loadModel, we don't really have an immediate need.
* [ ] ~~`rerender` itself should be moved to the `postEditor`, and the renderer should be passed to the `postEditor` instance.~~ seems coupled to loadModel concerns. Will revisit.