### PR TITLE
Add forward and backward deletion to PostEditor

### DIFF
--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -11,9 +11,12 @@ export default class PostNodeBuilder {
     this.markupCache = {};
   }
 
-  createPost() {
+  createPost(sections=[]) {
     const post = new Post();
     post.builder = this;
+
+    sections.forEach(s => post.sections.append(s));
+
     return post;
   }
 

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -1,4 +1,8 @@
 import Keycodes from './keycodes';
+export const DIRECTION = {
+  FORWARD: 1,
+  BACKWARD: 2
+};
 
 /**
  * An abstraction around a KeyEvent
@@ -22,6 +26,14 @@ const Key = class Key {
   isDelete() {
     return this.keyCode === Keycodes.BACKSPACE ||
            this.keyCode === Keycodes.DELETE;
+  }
+
+  isForwardDelete() {
+    return this.keyCode === Keycodes.DELETE;
+  }
+
+  get direction() {
+    return this.isForwardDelete() ? DIRECTION.FORWARD : DIRECTION.BACKWARD;
   }
 
   isSpace() {

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -145,7 +145,7 @@ function triggerDelete(editor) {
     let event = { preventDefault() {} };
     editor.handleDeletion(event);
   } else {
-    triggerKeyEvent(document, 'keydown', KEY_CODES.DELETE);
+    triggerKeyEvent(document, 'keydown', KEY_CODES.BACKSPACE);
   }
 }
 

--- a/tests/helpers/mobiledoc.js
+++ b/tests/helpers/mobiledoc.js
@@ -1,0 +1,28 @@
+import PostNodeBuilder from 'content-kit-editor/models/post-node-builder';
+import MobiledocRenderer from 'content-kit-editor/renderers/mobiledoc';
+
+/*
+ * usage:
+ *  makeMD(({post, section, marker, markup}) =>
+ *    post([
+ *      section('P', [
+ *        marker('some text', [markup('B')])
+ *      ])
+ *    })
+ *  )
+ */
+function build(treeFn) {
+  let builder = new PostNodeBuilder();
+
+  const post          = (...args) => builder.createPost(...args);
+  const markupSection = (...args) => builder.createMarkupSection(...args);
+  const markup        = (...args) => builder.createMarkup(...args);
+  const marker        = (...args) => builder.createMarker(...args);
+
+  let builtPost = treeFn({post, markupSection, markup, marker});
+  return MobiledocRenderer.render(builtPost);
+}
+
+export default {
+  build
+};

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -4,9 +4,11 @@ registerAssertions();
 import DOMHelpers from './helpers/dom';
 import ToolbarHelpers from './helpers/toolbar';
 import skipInPhantom from './helpers/skip-in-phantom';
+import MobiledocHelpers from './helpers/mobiledoc';
 
 export default {
   dom: DOMHelpers,
   toolbar: ToolbarHelpers,
-  skipInPhantom
+  skipInPhantom,
+  mobiledoc: MobiledocHelpers
 };

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -1,0 +1,159 @@
+import PostEditor from 'content-kit-editor/editor/post';
+import { Editor } from 'content-kit-editor';
+import Helpers from '../../test-helpers';
+import { DIRECTION } from 'content-kit-editor/utils/key';
+
+const { FORWARD } = DIRECTION;
+
+const { module, test } = window.QUnit;
+
+let editor, editorElement;
+
+function getSection(sectionIndex) {
+  return editor.post.sections.objectAt(sectionIndex);
+}
+
+function getMarker(sectionIndex, markerIndex) {
+  return getSection(sectionIndex).markers.objectAt(markerIndex);
+}
+
+function postEditorWithMobiledoc(treeFn) {
+  const mobiledoc = Helpers.mobiledoc.build(treeFn);
+  editor = new Editor(editorElement, {mobiledoc});
+  return new PostEditor(editor);
+}
+
+module('Unit: PostEditor', {
+  beforeEach() {
+    $('#qunit-fixture').append('<div id="editor"></div>');
+    editorElement = $('#editor')[0];
+  },
+
+  afterEach() {
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
+  }
+});
+
+test('#deleteFrom in middle of marker deletes char before offset', (assert) => {
+  const postEditor = postEditorWithMobiledoc(({post, markupSection, marker}) =>
+    post([
+      markupSection('P', [marker('abc def')])
+    ]) 
+  );
+
+  const nextPosition = postEditor.deleteFrom({marker: getMarker(0,0), offset:4});
+  postEditor.complete();
+
+  assert.equal(getMarker(0, 0).value, 'abcdef');
+  assert.deepEqual(nextPosition, {currentMarker: getMarker(0, 0), currentOffset: 3});
+});
+
+
+test('#deleteFrom (forward) in middle of marker deletes char after offset', (assert) => {
+  const postEditor = postEditorWithMobiledoc(({post, markupSection, marker}) =>
+    post([
+      markupSection('p', [marker('abc def')])
+    ])
+  );
+
+  const nextPosition = postEditor.deleteFrom({marker: getMarker(0,0), offset:3}, FORWARD);
+  postEditor.complete();
+
+  assert.equal(getMarker(0, 0).value, 'abcdef');
+  assert.deepEqual(nextPosition, {currentMarker: getMarker(0, 0), currentOffset: 3});
+});
+
+test('#deleteFrom offset 0 joins section with previous if first marker', (assert) => {
+  const postEditor = postEditorWithMobiledoc(({post, markupSection, marker}) =>
+    post([
+      markupSection('P', [marker('abc')]),
+      markupSection('P', [marker('def')])
+    ])
+  );
+
+  const nextPosition = postEditor.deleteFrom({marker: getMarker(1,0), offset:0});
+  postEditor.complete();
+
+  assert.equal(editor.post.sections.length, 1,
+               'sections joined');
+  assert.equal(getSection(0).markers.length, 2,
+               'joined section has 2 markers');
+
+  let newMarkers = getSection(0).markers.toArray();
+  let newValues = newMarkers.map(m => m.value);
+
+  assert.deepEqual(newValues, ['abc','def'], 'new markers have correct values');
+
+  assert.deepEqual(nextPosition,
+                   {currentMarker: getMarker(0, 0), currentOffset: newValues[0].length});
+});
+
+test('#deleteFrom (FORWARD) end of marker joins section with next if last marker', (assert) => {
+  const postEditor = postEditorWithMobiledoc(({post, markupSection, marker}) =>
+    post([
+      markupSection('P', [marker('abc')]),
+      markupSection('P', [marker('def')])
+    ])
+  );
+
+  let marker = getMarker(0,0);
+  const nextPosition = postEditor.deleteFrom({marker, offset:marker.length},
+                                             FORWARD);
+  postEditor.complete();
+
+  assert.equal(editor.post.sections.length, 1,
+               'sections joined');
+  assert.equal(getSection(0).markers.length, 2,
+               'joined section has 2 markers');
+
+  let newMarkers = getSection(0).markers.toArray();
+  let newValues = newMarkers.map(m => m.value);
+
+  assert.deepEqual(newValues, ['abc','def'], 'new markers have correct values');
+
+  assert.deepEqual(nextPosition,
+                   {currentMarker: getMarker(0, 0), currentOffset: newValues[0].length});
+});
+
+test('#deleteFrom offset 0 deletes last character of previous marker when there is one', (assert) => {
+  const postEditor = postEditorWithMobiledoc(({post, markupSection, marker}) =>
+    post([
+      markupSection('P', [marker('abc'), marker('def')])
+    ])
+  );
+
+  const nextPosition = postEditor.deleteFrom({marker: getMarker(0, 1), offset:0});
+  postEditor.complete();
+
+  let markers = getSection(0).markers.toArray();
+  let values = markers.map(m => m.value);
+
+  assert.deepEqual(values, ['ab', 'def'], 'markers have correct values');
+
+  assert.deepEqual(nextPosition,
+                   {currentMarker: getMarker(0, 0), currentOffset: values[0].length});
+});
+
+test('#deleteFrom (FORWARD) end of marker deletes first character of next marker when there is one', (assert) => {
+  const postEditor = postEditorWithMobiledoc(({post, markupSection, marker}) =>
+    post([
+      markupSection('P', [marker('abc'), marker('def')])
+    ])
+  );
+
+  let marker = getMarker(0, 0);
+  const nextPosition = postEditor.deleteFrom({marker, offset:marker.length},
+                                            FORWARD);
+  postEditor.complete();
+
+  let markers = getSection(0).markers.toArray();
+  let values = markers.map(m => m.value);
+
+  assert.deepEqual(values, ['abc', 'ef'], 'markers have correct values');
+
+  assert.deepEqual(nextPosition,
+                   {currentMarker: getMarker(0, 0), currentOffset: values[0].length});
+});


### PR DESCRIPTION
Changes `postEditor#deleteCharAt` to be `postEditor#deleteFrom(position, direction)`.

Adds unit tests for the `postEditor` directly that assert that it changes
the AT as expected.

Some cleanup in the editor as well to remove some duplicated code.

fixes #36

cc @mixonic