### PR TITLE
Split render from editor instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ var simpleMobiledoc = {
 };
 var element = document.querySelector('#editor');
 var options = { mobiledoc: simpleMobiledoc };
-var editor = new ContentKit.Editor(element, options);
+var editor = new ContentKit.Editor(options);
+editor.render(element);
 ```
 
 `options` is an object which may include the following properties:

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -269,7 +269,7 @@ function bootEditor(element, mobiledoc) {
   if (editor) {
     editor.destroy();
   }
-  editor = new ContentKit.Editor(element, {
+  editor = new ContentKit.Editor({
     autofocus: false,
     mobiledoc: mobiledoc,
     cards: [simpleCard, cardWithEditMode, cardWithInput, selfieCard],
@@ -279,6 +279,7 @@ function bootEditor(element, mobiledoc) {
       }
     }
   });
+  editor.render(element);
 
   function sync() {
     ContentKitDemo.syncCodePane(editor);

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -20,6 +20,11 @@ export default class PostNodeBuilder {
     return post;
   }
 
+  createBlankPost() {
+    let blankMarkupSection = this.createBlankMarkupSection('p');
+    return this.createPost([ blankMarkupSection ]);
+  }
+
   createMarkupSection(tagName, markers=[], isGenerated=false) {
     tagName = normalizeTagName(tagName);
     const section = new MarkupSection(tagName, markers);
@@ -28,6 +33,12 @@ export default class PostNodeBuilder {
     }
     section.builder = this;
     return section;
+  }
+
+  createBlankMarkupSection(tagName) {
+    tagName = normalizeTagName(tagName);
+    let blankMarker = this.createBlankMarker();
+    return this.createMarkupSection(tagName, [ blankMarker ]);
   }
 
   createImageSection(url) {

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -120,6 +120,12 @@ function normalizeTagName(tagName) {
   return tagName.toLowerCase();
 }
 
+function parseHTML(html) {
+  var div = document.createElement('div');
+  div.innerHTML = html;
+  return div;
+}
+
 export {
   detectParentNode,
   containsNode,
@@ -131,5 +137,6 @@ export {
   walkTextNodes,
   addClassName,
   normalizeTagName,
-  isTextNode
+  isTextNode,
+  parseHTML
 };

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -19,7 +19,8 @@ module('Acceptance: editor: basic', {
 test('sets element as contenteditable', (assert) => {
   let innerHTML = `<p>Hello</p>`;
   editorElement.innerHTML = innerHTML;
-  editor = new Editor(document.getElementById('editor'));
+  editor = new Editor();
+  editor.render(editorElement);
 
   assert.equal(editorElement.getAttribute('contenteditable'),
                'true',
@@ -31,7 +32,8 @@ test('sets element as contenteditable', (assert) => {
 test('#disableEditing and #enableEditing toggle contenteditable', (assert) => {
   let innerHTML = `<p>Hello</p>`;
   editorElement.innerHTML = innerHTML;
-  editor = new Editor(document.getElementById('editor'));
+  editor = new Editor();
+  editor.render(editorElement);
 
   assert.equal(editorElement.getAttribute('contenteditable'),
                'true',

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -58,7 +58,8 @@ module('Acceptance: editor: cards', {
 
 test('changing to display state triggers update on editor', (assert) => {
   const cards = [simpleCard];
-  editor = new Editor(editorElement, {mobiledoc, cards});
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
 
   let updateCount = 0,
       triggeredUpdate = () => updateCount++;

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -23,7 +23,8 @@ module('Acceptance: Editor commands', {
     editorElement = document.createElement('div');
     editorElement.setAttribute('id', 'editor');
     fixture.appendChild(editorElement);
-    editor = new Editor(editorElement, {mobiledoc});
+    editor = new Editor({mobiledoc});
+    editor.render(editorElement);
 
     selectedText = 'IS A';
     Helpers.dom.selectText(selectedText, editorElement);

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -100,7 +100,8 @@ module('Acceptance: Editor sections', {
 });
 
 test('typing enter inserts new section', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Section});
+  editor = new Editor({mobiledoc: mobileDocWith1Section});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
 
   Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 5);
@@ -112,7 +113,8 @@ test('typing enter inserts new section', (assert) => {
 });
 
 test('hitting enter in first section splits it correctly', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 2, 'precond - has 2 paragraphs');
 
   Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 3);
@@ -130,7 +132,8 @@ test('hitting enter in first section splits it correctly', (assert) => {
 });
 
 test('hitting enter at start of a section creates empty section where cursor was', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Section});
+  editor = new Editor({mobiledoc: mobileDocWith1Section});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
 
   Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 0);
@@ -148,7 +151,8 @@ test('hitting enter at start of a section creates empty section where cursor was
 });
 
 test('hitting enter at end of a section creates new empty section', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Section});
+  editor = new Editor({mobiledoc: mobileDocWith1Section});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 1, 'has 1 section to start');
 
   Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 'only section'.length);
@@ -165,7 +169,8 @@ test('hitting enter at end of a section creates new empty section', (assert) => 
 
 // Phantom does not recognize toggling contenteditable off
 Helpers.skipInPhantom('deleting across 2 sections does nothing if editing is disabled', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
   editor.disableEditing();
   assert.equal($('#editor p').length, 2, 'precond - has 2 sections to start');
 
@@ -179,7 +184,8 @@ Helpers.skipInPhantom('deleting across 2 sections does nothing if editing is dis
 });
 
 test('deleting across 2 sections merges them', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 2, 'precond - has 2 sections to start');
 
   const p0 = $('#editor p:eq(0)')[0],
@@ -194,7 +200,8 @@ test('deleting across 2 sections merges them', (assert) => {
 });
 
 test('deleting across 1 section removes it, joins the 2 boundary sections', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith3Sections});
+  editor = new Editor({mobiledoc: mobileDocWith3Sections});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 3, 'precond - has 3 paragraphs to start');
 
   const p0 = $('#editor p:eq(0)')[0],
@@ -211,7 +218,8 @@ test('deleting across 1 section removes it, joins the 2 boundary sections', (ass
 });
 
 test('keystroke of delete removes that character', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith3Sections});
+  editor = new Editor({mobiledoc: mobileDocWith3Sections});
+  editor.render(editorElement);
   const getFirstTextNode = () => {
     return editor.element.
              firstChild. // section
@@ -232,7 +240,8 @@ test('keystroke of delete removes that character', (assert) => {
 });
 
 test('keystroke of delete when cursor is at beginning of marker removes character from previous marker', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Markers});
+  editor = new Editor({mobiledoc: mobileDocWith2Markers});
+  editor.render(editorElement);
   const textNode = editor.element.
                     firstChild.    // section
                     childNodes[1]; // plain marker
@@ -255,7 +264,8 @@ test('keystroke of delete when cursor is at beginning of marker removes characte
 });
 
 test('keystroke of delete when cursor is after only char in only marker of section removes character', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Character});
+  editor = new Editor({mobiledoc: mobileDocWith1Character});
+  editor.render(editorElement);
   const getTextNode = () => editor.element.
                                   firstChild. // section
                                   firstChild; // c marker
@@ -273,7 +283,8 @@ test('keystroke of delete when cursor is after only char in only marker of secti
 });
 
 Helpers.skipInPhantom('keystroke of character in empty section adds character, moves cursor', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWithNoCharacter});
+  editor = new Editor({mobiledoc: mobileDocWithNoCharacter});
+  editor.render(editorElement);
   const getTextNode = () => editor.element.
                                   firstChild. // section
                                   firstChild; // marker
@@ -296,7 +307,8 @@ Helpers.skipInPhantom('keystroke of character in empty section adds character, m
 });
 
 test('keystroke of delete at start of section joins with previous section', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let secondSectionTextNode = editor.element.childNodes[1].firstChild;
 
@@ -322,7 +334,8 @@ test('keystroke of delete at start of section joins with previous section', (ass
 
 
 test('keystroke of delete at start of first section does nothing', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let firstSectionTextNode = editor.element.childNodes[0].firstChild;
 
@@ -348,7 +361,8 @@ test('keystroke of delete at start of first section does nothing', (assert) => {
 test('when selection incorrectly contains P end tag, editor reports correct selection', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let secondSectionTextNode = editor.element.childNodes[1].firstChild;
   let firstSectionPNode = editor.element.childNodes[0];
@@ -376,7 +390,8 @@ test('when selection incorrectly contains P end tag, editor reports correct sele
 test('when selection incorrectly contains P start tag, editor reports correct selection', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let firstSectionTextNode = editor.element.childNodes[0].firstChild;
   let secondSectionPNode = editor.element.childNodes[1];
@@ -405,7 +420,8 @@ test('when selection incorrectly contains P start tag, editor reports correct se
 test('deleting when after deletion there is a trailing space positions cursor at end of selection', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let firstSectionTextNode = editor.element.childNodes[0].firstChild;
   Helpers.dom.moveCursorTo(firstSectionTextNode, 'first section'.length);
@@ -434,7 +450,8 @@ test('deleting when after deletion there is a trailing space positions cursor at
 test('deleting when after deletion there is a leading space positions cursor at start of selection', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('second', editorElement);
   Helpers.dom.triggerDelete(editor);

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -37,7 +37,8 @@ module('Acceptance: Editor Selections', {
 test('selecting across sections is possible', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let firstSection = $('p:contains(first section)')[0];
   let secondSection = $('p:contains(second section)')[0];
@@ -56,7 +57,8 @@ test('selecting across sections is possible', (assert) => {
 test('selecting an entire section and deleting removes it', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('second section', editorElement);
   Helpers.dom.triggerDelete(editor);
@@ -73,7 +75,8 @@ test('selecting an entire section and deleting removes it', (assert) => {
 });
 
 test('selecting text in a section and deleting deletes it', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('cond sec', editorElement);
   Helpers.dom.triggerDelete(editor);
@@ -91,7 +94,8 @@ test('selecting text in a section and deleting deletes it', (assert) => {
 });
 
 test('selecting text across sections and deleting joins sections', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   const firstSection = $('#editor p')[0],
         secondSection = $('#editor p')[1];
@@ -109,7 +113,8 @@ test('selecting text across sections and deleting joins sections', (assert) => {
 test('selecting text across markers and deleting joins markers', (assert) => {
   const done = assert.async();
 
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('rst sect', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
@@ -148,7 +153,8 @@ test('selecting text across markers and deleting joins markers', (assert) => {
 
 test('select text and apply markup multiple times', (assert) => {
   const done = assert.async();
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('t sect', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
@@ -173,7 +179,8 @@ test('select text and apply markup multiple times', (assert) => {
 
 test('selecting text across markers deletes intermediary markers', (assert) => {
   const done = assert.async();
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('rst sec', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
@@ -202,7 +209,8 @@ test('selecting text across markers deletes intermediary markers', (assert) => {
 
 test('selecting text across markers preserves node after', (assert) => {
   const done = assert.async();
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('rst sec', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');
@@ -233,7 +241,8 @@ test('selecting text across markers preserves node after', (assert) => {
 
 test('selecting text across sections and hitting enter deletes and moves cursor to last selected section', (assert) => {
   const done = assert.async();
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   let firstSection = $('#editor p:eq(0)')[0],
       secondSection = $('#editor p:eq(1)')[0];
@@ -258,7 +267,8 @@ test('selecting text across sections and hitting enter deletes and moves cursor 
 
 Helpers.skipInPhantom('keystroke of printable character while text is selected deletes the text', (assert) => {
   const done = assert.async();
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith2Sections});
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
 
   Helpers.dom.selectText('first section', editorElement);
   Helpers.dom.triggerEvent(document, 'mouseup');

--- a/tests/acceptance/embed-intent-test.js
+++ b/tests/acceptance/embed-intent-test.js
@@ -48,7 +48,8 @@ module('Acceptance: Embed intent', {
 });
 
 Helpers.skipInPhantom('typing inserts empty section and displays embed-intent button', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Section});
+  editor = new Editor({mobiledoc: mobileDocWith1Section});
+  editor.render(editorElement);
   assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
   assert.hasNoElement('.ck-embed-intent', 'embed intent is hidden');
 
@@ -60,7 +61,8 @@ Helpers.skipInPhantom('typing inserts empty section and displays embed-intent bu
 });
 
 Helpers.skipInPhantom('add image card between sections', (assert) => {
-  editor = new Editor(editorElement, {mobiledoc: mobileDocWith3Sections});
+  editor = new Editor({mobiledoc: mobileDocWith3Sections});
+  editor.render(editorElement);
   assert.equal(editorElement.childNodes.length, 3, 'has 3 paragraphs to start');
 
   Helpers.dom.moveCursorTo(editorElement.childNodes[1].firstChild, 0);

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -52,11 +52,12 @@ test('rendering a mobiledoc for editing calls card#setup', (assert) => {
       ]
     ]
   };
-  editor = new Editor(editorElement, {
+  editor = new Editor({
     mobiledoc,
     cards: [card],
     cardOptions
   });
+  editor.render(editorElement);
 });
 
 test('rendering a mobiledoc for editing calls #unknownCardHandler when it encounters an unknown card', (assert) => {
@@ -78,7 +79,8 @@ test('rendering a mobiledoc for editing calls #unknownCardHandler when it encoun
     ]
   };
 
-  editor = new Editor(editorElement, {mobiledoc, unknownCardHandler});
+  editor = new Editor({mobiledoc, unknownCardHandler});
+  editor.render(editorElement);
 });
 
 test('rendered card can fire edit hook to enter editing mode', (assert) => {
@@ -129,11 +131,12 @@ test('rendered card can fire edit hook to enter editing mode', (assert) => {
       ]
     ]
   };
-  editor = new Editor(editorElement, {
+  editor = new Editor({
     mobiledoc,
     cards: [card],
     cardOptions
   });
+  editor.render(editorElement);
 
   Helpers.dom.triggerEvent(span, 'click');
 });
@@ -175,10 +178,11 @@ test('rendered card can fire edit hook to enter editing mode, then save', (asser
       ]
     ]
   };
-  editor = new Editor(editorElement, {
+  editor = new Editor({
     mobiledoc,
     cards: [card]
   });
+  editor.render(editorElement);
 
   doEdit();
   doSave();
@@ -222,10 +226,11 @@ test('rendered card can fire edit hook to enter editing mode, then cancel', (ass
       ]
     ]
   };
-  editor = new Editor(editorElement, {
+  editor = new Editor({
     mobiledoc,
     cards: [card]
   });
+  editor.render(editorElement);
 
   doEdit();
   doCancel();

--- a/tests/unit/editor/editor-destroy-test.js
+++ b/tests/unit/editor/editor-destroy-test.js
@@ -23,7 +23,8 @@ module('Unit: Editor #destroy', {
     let fixture = $('#qunit-fixture')[0];
     editorElement = document.createElement('div');
     fixture.appendChild(editorElement);
-    editor = new Editor(editorElement, {mobiledoc});
+    editor = new Editor({mobiledoc});
+    editor.render(editorElement);
   },
   afterEach() {
     if (editor && !editor._isDestroyed) {

--- a/tests/unit/editor/editor-events-test.js
+++ b/tests/unit/editor/editor-events-test.js
@@ -22,7 +22,8 @@ module('Unit: Editor: events', {
     editorElement = document.createElement('div');
     document.getElementById('qunit-fixture').appendChild(editorElement);
 
-    editor = new Editor(editorElement, {mobiledoc});
+    editor = new Editor({mobiledoc});
+    editor.render(editorElement);
     editor.trigger = (name) => triggered.push(name);
   },
 

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -24,7 +24,8 @@ function getMarker(sectionIndex, markerIndex) {
 
 function postEditorWithMobiledoc(treeFn) {
   const mobiledoc = Helpers.mobiledoc.build(treeFn);
-  editor = new Editor(editorElement, {mobiledoc});
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
   return new PostEditor(editor);
 }
 


### PR DESCRIPTION
Drop the element argument from editor instantiation.

Should this perhaps be `editor.append`?

Fixes https://github.com/bustlelabs/content-kit-editor/issues/88