### PR TITLE
Remove UNPRINTABLE_CHARACTER, use <br> instead

### DIFF
--- a/src/js/models/cursor.js
+++ b/src/js/models/cursor.js
@@ -9,9 +9,33 @@ import {
 
 import {
   detectParentNode,
-  isTextNode
+  isTextNode,
+  walkDOM
 } from '../utils/dom-utils';
 
+function findOffsetInParent(parentElement, targetElement, targetOffset) {
+  let offset = 0;
+  let found = false;
+  // FIXME: would be nice to exit this walk early after we find the end node
+  walkDOM(parentElement, (childElement) => {
+    if (found) { return; }
+    found = childElement === targetElement;
+
+    if (found) {
+      offset += targetOffset;
+    } else if (isTextNode(childElement)) {
+      offset += childElement.textContent.length;
+    }
+  });
+  return offset;
+}
+
+function findSectionContaining(sections, childNode) {
+  const {result:section} = detectParentNode(childNode, node => {
+    return detect(sections, s => s.renderNode.element === node);
+  });
+  return section;
+}
 
 function comparePosition(selection) {
   let { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
@@ -55,7 +79,8 @@ export default class Cursor {
     return window.getSelection();
   }
 
-  get offsets() {
+  get sectionOffsets() {
+    const { sections } = this.post;
     const selection = this.selection;
     const { rangeCount } = selection;
     const range = rangeCount > 0 && selection.getRangeAt(0);
@@ -64,26 +89,64 @@ export default class Cursor {
       return {};
     }
 
-    let {leftNode, leftOffset, rightNode, rightOffset} =
-      comparePosition(selection);
+    let {leftNode:headNode, leftOffset:headOffset} = comparePosition(selection);
+    let headSection = findSectionContaining(sections, headNode);
+    let headSectionOffset = findOffsetInParent(headSection.renderNode.element, headNode, headOffset);
 
-    // The selection should contain two text nodes.
-    // On Chrome/Safari using shift+<Up arrow> can create a selection with
-    // a tag rather than a text node. This fixes that.
-    // See https://github.com/bustlelabs/content-kit-editor/issues/56
-    if (!isTextNode(rightNode)) {
-      rightNode = rightNode.previousSibling.lastChild;
-      rightOffset = rightNode.textContent.length;
+    return {headSection, headSectionOffset};
+  }
+
+  get offsets() {
+    const { sections } = this.post;
+    const selection = this.selection;
+    const { isCollapsed, rangeCount } = selection;
+    const range = rangeCount > 0 && selection.getRangeAt(0);
+
+    if (!range) {
+      return {};
     }
 
-    const leftRenderNode = this.renderTree.elements.get(leftNode),
-          rightRenderNode = this.renderTree.elements.get(rightNode);
+
+    let {leftNode, leftOffset, rightNode, rightOffset} = comparePosition(selection);
+
+    // The selection should contain two text nodes, but may contain a P
+    // tag if the section only has a blank br marker or on
+    // Chrome/Safari using shift+<Up arrow> can create a selection with
+    // a tag rather than a text node. This fixes that.
+    // See https://github.com/bustlelabs/content-kit-editor/issues/56
+
+    let leftRenderNode = this.renderTree.getElementRenderNode(leftNode),
+        rightRenderNode = this.renderTree.getElementRenderNode(rightNode);
+
+    if (!rightRenderNode) {
+      let rightSection = findSectionContaining(sections, rightNode);
+      let rightMarker = rightSection.markers.head;
+      rightRenderNode = rightMarker.renderNode;
+      rightNode = rightRenderNode.element;
+      rightOffset = 0;
+    }
+
+    if (!leftRenderNode) {
+      let leftSection = findSectionContaining(sections, leftNode);
+      let leftMarker = leftSection.markers.head;
+      leftRenderNode = leftMarker.renderNode;
+      leftNode = leftRenderNode.element;
+      leftOffset = 0;
+    }
 
     const startMarker = leftRenderNode && leftRenderNode.postNode,
           endMarker = rightRenderNode && rightRenderNode.postNode;
 
     const startSection = startMarker && startMarker.section;
     const endSection = endMarker && endMarker.section;
+
+    const headSectionOffset = startSection &&
+      startMarker &&
+      startMarker.offsetInParent(leftOffset);
+
+    const tailSectionOffset = endSection &&
+      endMarker &&
+      endMarker.offsetInParent(rightOffset);
 
     return {
       leftNode,
@@ -101,7 +164,15 @@ export default class Cursor {
       headMarker: startMarker,
       tailMarker: endMarker,
       headOffset: leftOffset,
-      tailOffset: rightOffset
+      tailOffset: rightOffset,
+      headNode: leftNode,
+      tailNode: rightNode,
+
+      headSection: startSection,
+      tailSection: endSection,
+      headSectionOffset,
+      tailSectionOffset,
+      isCollapsed
     };
   }
 
@@ -116,20 +187,17 @@ export default class Cursor {
     }
 
     const { startContainer, endContainer } = range;
-    const isSectionElement = (element) => {
-      return detect(sections, s => s.renderNode.element === element);
-    };
-    const {result:startSection} = detectParentNode(startContainer, isSectionElement);
-    const {result:endSection} = detectParentNode(endContainer, isSectionElement);
+    const startSection = findSectionContaining(sections, startContainer);
+    const endSection = findSectionContaining(sections, endContainer);
 
     return sections.readRange(startSection, endSection);
   }
 
   // moves cursor to the start of the section
-  moveToSection(section) {
-    const marker = section.markers.head;
+  moveToSection(section, offsetInSection=0) {
+    const {marker, offset} = section.markerPositionAtOffset(offsetInSection);
     if (!marker) { throw new Error('Cannot move cursor to section without a marker'); }
-    this.moveToMarker(marker);
+    this.moveToMarker(marker, offset);
   }
 
   // moves cursor to marker

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -50,6 +50,32 @@ const Marker = class Marker extends LinkedItem {
     this.markups.push(markup);
   }
 
+  // find the value of the absolute offset in this marker's parent section
+  offsetInParent(offset) {
+    const parent = this.section;
+    const markers = parent.markers;
+
+    let foundMarker = false;
+    let parentOffset = 0;
+    let marker = markers.head;
+    var length;
+    while (marker && !foundMarker) {
+      length = marker.length;
+      if (marker === this) {
+        foundMarker = true;
+        length = offset;
+      }
+
+      parentOffset += length;
+      marker = marker.next;
+    }
+
+    if (!foundMarker) {
+      throw new Error('offsetInParent could not find offset for marker');
+    }
+    return parentOffset;
+  }
+
   removeMarkup(markup) {
     const index = this.markups.indexOf(markup);
     if (index !== -1) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -5,60 +5,73 @@ export default class Post {
   constructor() {
     this.type = POST_TYPE;
     this.sections = new LinkedList({
-      adoptItem(section) {
-        section.post = this;
-      },
-      freeItem(section) {
-        section.post = null;
-      }
+      adoptItem: s => s.post = this,
+      freeItem: s => s.post = null
     });
   }
+
+  markersInRange({headMarker, headOffset, tailMarker, tailOffset}) {
+    let offset = 0;
+    let foundMarkers = [];
+    let toEnd = tailOffset === undefined;
+    if (toEnd) { tailOffset = 0; }
+
+    this.markersFrom(headMarker, tailMarker, marker => {
+      if (toEnd) {
+        tailOffset += marker.length;
+      }
+
+      if (offset >= headOffset && offset < tailOffset) {
+        foundMarkers.push(marker);
+      }
+
+      offset += marker.length;
+    });
+
+    return foundMarkers;
+  }
+
   cutMarkers(markers) {
-    let firstSection = markers[0].section,
-        lastSection  = markers[markers.length - 1].section;
+    let firstSection = markers.length && markers[0].section,
+        lastSection  = markers.length && markers[markers.length - 1].section;
 
     let currentSection = firstSection;
     let removedSections = [],
-        changedSections = [firstSection, lastSection];
-
-    let previousMarker = markers[0].prev;
-
-    markers.forEach(marker => {
-      if (marker.section !== currentSection) { // this marker is in a section we haven't seen yet
-        if (marker.section !== firstSection &&
-            marker.section !== lastSection) {
-          // section is wholly contained by markers, and can be removed
-          removedSections.push(marker.section);
+        changedSections = [];
+    if (firstSection) {
+      changedSections.push(firstSection);
+    }
+    if (lastSection) {
+      changedSections.push(lastSection);
+    }
+    if (markers.length !== 0) {
+      markers.forEach(marker => {
+        if (marker.section !== currentSection) { // this marker is in a section we haven't seen yet
+          if (marker.section !== firstSection &&
+              marker.section !== lastSection) {
+            // section is wholly contained by markers, and can be removed
+            removedSections.push(marker.section);
+          }
         }
+
+        currentSection = marker.section;
+        currentSection.markers.remove(marker);
+      });
+
+      // add a blank marker to any sections that are now empty
+      changedSections.forEach(section => {
+        if (section.markers.isEmpty) {
+          section.markers.append(this.builder.createBlankMarker());
+        }
+      });
+
+      if (firstSection !== lastSection) {
+        firstSection.join(lastSection);
+        removedSections.push(lastSection);
       }
-
-      currentSection = marker.section;
-      currentSection.markers.remove(marker);
-    });
-
-    // add a blank marker to any sections that are now empty
-    changedSections.forEach(section => {
-      if (section.markers.isEmpty) {
-        section.markers.append(this.builder.createBlankMarker());
-      }
-    });
-
-    let currentMarker, currentOffset;
-
-    if (previousMarker) {
-      currentMarker = previousMarker;
-      currentOffset = currentMarker.length;
-    } else {
-      currentMarker = firstSection.markers.head;
-      currentOffset = 0;
     }
 
-    if (firstSection !== lastSection) {
-      firstSection.join(lastSection);
-      removedSections.push(lastSection);
-    }
-
-    return {changedSections, removedSections, currentMarker, currentOffset};
+    return {changedSections, removedSections};
   }
   /**
    * Invoke `callbackFn` for all markers between the startMarker and endMarker (inclusive),
@@ -75,7 +88,7 @@ export default class Post {
         currentMarker = currentMarker.next;
       } else {
         let nextSection = currentMarker.section.next;
-        currentMarker = nextSection.markers.head;
+        currentMarker = nextSection && nextSection.markers.head;
       }
     }
   }

--- a/src/js/models/render-node.js
+++ b/src/js/models/render-node.js
@@ -9,6 +9,7 @@ export default class RenderNode extends LinkedItem {
     this.isRemoved = false;
     this.postNode = postNode;
     this._childNodes = null;
+    this.element = null;
   }
   get childNodes() {
     if (!this._childNodes) {
@@ -39,13 +40,5 @@ export default class RenderNode extends LinkedItem {
   }
   markClean() {
     this.isDirty = false;
-  }
-  set element(element) {
-    this._element = element;
-    this.renderTree.elements.set(element, this);
-    return element;
-  }
-  get element() {
-    return this._element;
   }
 }

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -78,7 +78,7 @@ export default class PostParser {
 
       let marker;
 
-      let renderNode = renderTree.elements.get(textNode);
+      let renderNode = renderTree.getElementRenderNode(textNode);
       if (renderNode) {
         if (text.length) {
           marker = renderNode.postNode;
@@ -121,14 +121,17 @@ export default class PostParser {
     });
 
     // remove any nodes that were not marked as seen
-    let renderNode = section.renderNode.firstChild;
-    while (renderNode) {
-      if (seenRenderNodes.indexOf(renderNode) === -1) {
-        // remove it
-        renderNode.scheduleForRemoval();
+    section.renderNode.childNodes.forEach(childRenderNode => {
+      if (seenRenderNodes.indexOf(childRenderNode) === -1) {
+        childRenderNode.scheduleForRemoval();
       }
+    });
 
-      renderNode = renderNode.next;
+    /** FIXME that we are reparsing and there are no markers should never
+     * happen. We manage the delete key on our own. */
+    if (section.markers.isEmpty) {
+      let marker = this.builder.createBlankMarker();
+      section.markers.append(marker);
     }
   }
 }

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -127,6 +127,7 @@ export {
   getAttributes,
   getAttributesArray,
   walkDOMUntil,
+  walkDOM,
   walkTextNodes,
   addClassName,
   normalizeTagName,

--- a/src/js/utils/element-utils.js
+++ b/src/js/utils/element-utils.js
@@ -1,4 +1,3 @@
-import { UNPRINTABLE_CHARACTER } from 'content-kit-editor/renderers/editor-dom';
 import { dasherize } from 'content-kit-editor/utils/string-utils';
 import {
   normalizeTagName
@@ -34,16 +33,6 @@ function getEventTargetMatchingTag(tagName, target, container) {
     }
     target = target.parentNode;
   }
-}
-
-function elementContentIsEmpty(element) {
-  if (!element.firstChild) {
-    return true;
-  } else if (element.childNodes.length === 1 &&
-             element.firstChild.textContent === UNPRINTABLE_CHARACTER) {
-    return true;
-  }
-  return false;
 }
 
 function getElementRelativeOffset(element) {
@@ -138,7 +127,6 @@ export {
   showElement,
   swapElements,
   getEventTargetMatchingTag,
-  elementContentIsEmpty,
   getElementRelativeOffset,
   getElementComputedStyleNumericProp,
   positionElementToRect,

--- a/src/js/utils/linked-list.js
+++ b/src/js/utils/linked-list.js
@@ -111,16 +111,21 @@ export default class LinkedList {
       item = item.next;
     }
   }
-  readRange(startItem, endItem) {
-    let items = [];
+  walk(startItem, endItem, callback) {
     let item = startItem || this.head;
     while (item) {
-      items.push(item);
+      callback(item);
       if (item === endItem) {
         break;
       }
       item = item.next;
     }
+  }
+  readRange(startItem, endItem) {
+    let items = [];
+    this.walk(startItem, endItem, (item) => {
+      items.push(item);
+    });
     return items;
   }
   toArray() {

--- a/src/js/views/embed-intent.js
+++ b/src/js/views/embed-intent.js
@@ -1,8 +1,7 @@
 import View from './view';
 import Toolbar from './toolbar';
 import { inherit } from 'content-kit-utils';
-import { getSelectionBlockElement } from '../utils/selection-utils';
-import { elementContentIsEmpty, positionElementToLeftOf, positionElementCenteredIn } from '../utils/element-utils';
+import { positionElementToLeftOf, positionElementCenteredIn } from '../utils/element-utils';
 import { createDiv } from '../utils/element-utils';
 import Keycodes from '../utils/keycodes';
 
@@ -49,14 +48,21 @@ function EmbedIntent(options) {
     direction: Toolbar.Direction.RIGHT
   });
 
-  function embedIntentHandler() {
-    var blockElement = getSelectionBlockElement();
-    if (blockElement && elementContentIsEmpty(blockElement)) {
-      embedIntent.showAt(blockElement);
+  const embedIntentHandler = () => {
+    const {editorContext:editor} = this;
+    if (this._isDestroyed || editor._isDestroyed) {
+      return;
+    }
+
+    const {headSection, isCollapsed} = embedIntent.editorContext.cursor.offsets;
+    const headRenderNode = headSection && headSection.renderNode && headSection.renderNode.element;
+
+    if (headRenderNode && headSection.isBlank && isCollapsed) {
+      embedIntent.showAt(headRenderNode);
     } else {
       embedIntent.hide();
     }
-  }
+  };
 
   this.addEventListener(rootElement, 'keyup', embedIntentHandler);
   this.addEventListener(document, 'click', () => {

--- a/src/js/views/view.js
+++ b/src/js/views/view.js
@@ -62,6 +62,7 @@ class View {
   destroy() {
     this.removeAllEventListeners();
     this.hide();
+    this._isDestroyed = true;
   }
 }
 

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -12,9 +12,7 @@ module('Acceptance: editor: basic', {
     fixture.appendChild(editorElement);
   },
   afterEach() {
-    if (editor) {
-      editor.destroy();
-    }
+    if (editor) { editor.destroy(); }
   }
 });
 

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -52,9 +52,7 @@ module('Acceptance: editor: cards', {
     fixture.appendChild(editorElement);
   },
   afterEach() {
-    if (editor) {
-      editor.destroy();
-    }
+    if (editor) { editor.destroy(); }
   }
 });
 

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -31,7 +31,7 @@ module('Acceptance: Editor commands', {
   },
 
   afterEach() {
-    editor.destroy();
+    if (editor) { editor.destroy(); }
   }
 });
 

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -30,9 +30,7 @@ module('Acceptance: Editor Selections', {
   },
 
   afterEach() {
-    if (editor) {
-      editor.destroy();
-    }
+    if (editor) { editor.destroy(); }
   }
 });
 
@@ -67,12 +65,9 @@ test('selecting an entire section and deleting removes it', (assert) => {
   assert.hasNoElement('p:contains(second section)', 'deletes contents of second section');
   assert.equal($('#editor p').length, 2, 'still has 2 sections');
 
-  let textNode = editorElement
-                  .childNodes[1] // second section p
-                  .childNodes[0]; // textNode
+  Helpers.dom.insertText('X');
 
-  assert.deepEqual(Helpers.dom.getCursorPosition(),
-                   {node: textNode, offset: 0});
+  assert.hasElement('#editor p:eq(1):contains(X)', 'inserts text in correct spot');
 
   done();
 });

--- a/tests/acceptance/embed-intent-test.js
+++ b/tests/acceptance/embed-intent-test.js
@@ -43,20 +43,18 @@ module('Acceptance: Embed intent', {
   },
 
   afterEach() {
-    if (editor) {
-      editor.destroy();
-    }
+    if (editor) { editor.destroy(); }
   }
 });
 
-Helpers.skipInPhantom('typing inserts section', (assert) => {
+Helpers.skipInPhantom('typing inserts empty section and displays embed-intent button', (assert) => {
   editor = new Editor(editorElement, {mobiledoc: mobileDocWith1Section});
   assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
   assert.hasNoElement('.ck-embed-intent', 'embed intent is hidden');
 
   Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 12);
-  Helpers.dom.triggerKeyEvent(editorElement, 'keydown', Helpers.dom.KEY_CODES.ENTER);
-  Helpers.dom.triggerKeyEvent(editorElement, 'keyup', Helpers.dom.KEY_CODES.ENTER);
+  Helpers.dom.triggerEnter(editor);
+  Helpers.dom.triggerEvent(editorElement, 'keyup');
 
   assert.ok($('.ck-embed-intent').is(':visible'), 'embed intent appears');
 });

--- a/tests/helpers/mobiledoc.js
+++ b/tests/helpers/mobiledoc.js
@@ -1,4 +1,4 @@
-import PostNodeBuilder from 'content-kit-editor/models/post-node-builder';
+import PostAbstractHelpers from './post-abstract';
 import MobiledocRenderer from 'content-kit-editor/renderers/mobiledoc';
 
 /*
@@ -12,15 +12,7 @@ import MobiledocRenderer from 'content-kit-editor/renderers/mobiledoc';
  *  )
  */
 function build(treeFn) {
-  let builder = new PostNodeBuilder();
-
-  const post          = (...args) => builder.createPost(...args);
-  const markupSection = (...args) => builder.createMarkupSection(...args);
-  const markup        = (...args) => builder.createMarkup(...args);
-  const marker        = (...args) => builder.createMarker(...args);
-
-  let builtPost = treeFn({post, markupSection, markup, marker});
-  return MobiledocRenderer.render(builtPost);
+  return MobiledocRenderer.render(PostAbstractHelpers.build(treeFn));
 }
 
 export default {

--- a/tests/helpers/post-abstract.js
+++ b/tests/helpers/post-abstract.js
@@ -1,0 +1,26 @@
+import PostNodeBuilder from 'content-kit-editor/models/post-node-builder';
+
+/*
+ * usage:
+ *  makeMD(({post, section, marker, markup}) =>
+ *    post([
+ *      section('P', [
+ *        marker('some text', [markup('B')])
+ *      ])
+ *    })
+ *  )
+ */
+function build(treeFn) {
+  let builder = new PostNodeBuilder();
+
+  const post          = (...args) => builder.createPost(...args);
+  const markupSection = (...args) => builder.createMarkupSection(...args);
+  const markup        = (...args) => builder.createMarkup(...args);
+  const marker        = (...args) => builder.createMarker(...args);
+
+  return treeFn({post, markupSection, markup, marker});
+}
+
+export default {
+  build
+};

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -5,10 +5,19 @@ import DOMHelpers from './helpers/dom';
 import ToolbarHelpers from './helpers/toolbar';
 import skipInPhantom from './helpers/skip-in-phantom';
 import MobiledocHelpers from './helpers/mobiledoc';
+import PostAbstract from './helpers/post-abstract';
+
+const { test } = QUnit;
+function skip(message) {
+  message = `[SKIPPED] ${message}`;
+  test(message, (assert) => assert.ok(true));
+}
 
 export default {
   dom: DOMHelpers,
   toolbar: ToolbarHelpers,
   skipInPhantom,
-  mobiledoc: MobiledocHelpers
+  mobiledoc: MobiledocHelpers,
+  postAbstract: PostAbstract,
+  skip
 };

--- a/tests/unit/editor/editor-destroy-test.js
+++ b/tests/unit/editor/editor-destroy-test.js
@@ -26,7 +26,7 @@ module('Unit: Editor #destroy', {
     editor = new Editor(editorElement, {mobiledoc});
   },
   afterEach() {
-    if (editor) {
+    if (editor && !editor._isDestroyed) {
       editor.destroy();
     }
   }

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -1,24 +1,26 @@
-import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
-import Editor, { EDITOR_ELEMENT_CLASS_NAME } from 'content-kit-editor/editor/editor';
+import Editor from 'content-kit-editor/editor/editor';
+import { EDITOR_ELEMENT_CLASS_NAME } from 'content-kit-editor/editor/editor';
 import { normalizeTagName } from 'content-kit-editor/utils/dom-utils';
+import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
 
 const { module, test } = window.QUnit;
 
-let fixture = document.getElementById('qunit-fixture');
-let editorElement = document.createElement('div');
+let editorElement;
 let editor;
-editorElement.id = 'editor1';
-editorElement.className = 'editor';
 
 module('Unit: Editor', {
-  beforeEach: function() {
+  beforeEach() {
+    let fixture = document.getElementById('qunit-fixture');
+    editorElement = document.createElement('div');
+    editorElement.id = 'editor1';
+    editorElement.className = 'editor';
     fixture.appendChild(editorElement);
   },
-  afterEach: function() {
+
+  afterEach() {
     if (editor) {
       editor.destroy();
     }
-    fixture.removeChild(editorElement);
   }
 });
 
@@ -40,14 +42,14 @@ test('can create an editor via dom node reference from getElementById', (assert)
 test('creating an editor without a class name adds appropriate class', (assert) => {
   editorElement.className = '';
 
-  var editor = new Editor(document.getElementById('editor1'));
+  editor = new Editor(document.getElementById('editor1'));
   assert.equal(editor.element.className, EDITOR_ELEMENT_CLASS_NAME);
 });
 
 test('creating an editor adds EDITOR_ELEMENT_CLASS_NAME if not there', (assert) => {
   editorElement.className = 'abc def';
 
-  var editor = new Editor(document.getElementById('editor1'));
+  editor = new Editor(document.getElementById('editor1'));
   const hasClass = (className) => editor.element.classList.contains(className);
   assert.ok(hasClass(EDITOR_ELEMENT_CLASS_NAME), 'has editor el class name');
   assert.ok(hasClass('abc') && hasClass('def'), 'preserves existing class names');
@@ -57,7 +59,7 @@ test('editor fires update event', (assert) => {
   assert.expect(2);
   let done = assert.async();
 
-  var editor = new Editor(editorElement);
+  editor = new Editor(editorElement);
   editor.on('update', function(data) {
     assert.equal(this, editor);
     assert.equal(data.index, 99);
@@ -79,7 +81,7 @@ test('editor parses and renders mobiledoc format', (assert) => {
     ]
   };
   editorElement.innerHTML = '<p>something here</p>';
-  let editor = new Editor(editorElement, {mobiledoc});
+  editor = new Editor(editorElement, {mobiledoc});
 
   assert.ok(editor.mobiledoc, 'editor has mobiledoc');
   assert.equal(editorElement.innerHTML,

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -56,6 +56,15 @@ test('#splitMarker does not create an empty marker if offset=0', (assert) => {
   assert.equal(s.markers.tail.value, 'there!', 'original 2nd marker unchanged');
 });
 
+test('#splitMarker does not remove an existing marker when the offset and endOffset are 0', (assert) => {
+  const m1 = builder.createMarker('X');
+  const s = builder.createMarkupSection('p', [m1]);
+  s.splitMarker(m1, 0, 0);
+
+  assert.equal(s.markers.length, 1, 'still 1 marker');
+  assert.equal(s.markers.head.value, 'X', 'still correct marker value');
+});
+
 test('#coalesceMarkers removes empty markers', (assert) => {
   const m1 = builder.createBlankMarker();
   const m2 = builder.createBlankMarker();
@@ -98,4 +107,64 @@ test('#isBlank returns false if there is a marker with length', (assert) => {
   const m = builder.createMarker('a');
   const s = builder.createMarkupSection('p', [m]);
   assert.ok(!s.isBlank, 'section with marker is not blank');
+});
+
+test('#markersFor clones markers', (assert) => {
+  const m = builder.createMarker('a');
+  const s = builder.createMarkupSection('p', [m]);
+  const clones = s.markersFor(0, 1);
+  assert.equal(clones.length, 1, 'correct number of clones are created');
+  assert.ok(clones[0] !== m, 'marker is cloned');
+  assert.equal(clones[0].value, m.value, 'marker content is the same');
+});
+
+test('#markersFor clones markers, trimming at tailOffset', (assert) => {
+  const m1 = builder.createMarker('ab');
+  const m2 = builder.createMarker('cd');
+  const s = builder.createMarkupSection('p', [m1, m2]);
+  const clones = s.markersFor(0, 3);
+  assert.equal(clones.length, 2, 'correct number of clones are created');
+  assert.equal(clones[0].value, 'ab', 'marker content correct');
+  assert.equal(clones[1].value, 'c', 'marker content is correct');
+});
+
+test('#markersFor clones markers, trimming at headOffset', (assert) => {
+  const m1 = builder.createMarker('ab');
+  const m2 = builder.createMarker('cd');
+  const s = builder.createMarkupSection('p', [m1, m2]);
+  const clones = s.markersFor(1, 4);
+  assert.equal(clones.length, 2, 'correct number of clones are created');
+  assert.equal(clones[0].value, 'b', 'marker content correct');
+  assert.equal(clones[1].value, 'cd', 'marker content is correct');
+});
+
+test('#markersFor clones markers, trimming at offsets that do not trim', (assert) => {
+  const m1 = builder.createMarker('ab');
+  const m2 = builder.createMarker('cd');
+  const m3 = builder.createMarker('ef');
+  const s = builder.createMarkupSection('p', [m1, m2, m3]);
+  const clones = s.markersFor(2, 4);
+  assert.equal(clones.length, 1, 'correct number of clones are created');
+  assert.equal(clones[0].value, 'cd', 'marker content correct');
+});
+
+test('#markersFor clones markers when offset completely surrounds a marker', (assert) => {
+  const m1 = builder.createMarker('ab');  // 0-2
+  const m2 = builder.createMarker('cd1'); // 2-5
+  const m3 = builder.createMarker('cd2'); // 5-8
+  const m4 = builder.createMarker('ef');  // 8-10
+  const s = builder.createMarkupSection('p', [m1, m2, m3, m4]);
+  const clones = s.markersFor(3, 9);
+  assert.equal(clones.length, 3, 'correct number of clones are created');
+  assert.equal(clones[0].value, 'd1', 'marker content correct');
+  assert.equal(clones[1].value, 'cd2', 'marker content correct');
+  assert.equal(clones[2].value, 'e', 'marker content correct');
+});
+
+test('#markersFor clones a single marker with a tail offset', (assert) => {
+  const m1 = builder.createMarker(' def');
+  const s = builder.createMarkupSection('p', [m1]);
+  const clones = s.markersFor(0,1);
+  assert.equal(clones.length, 1);
+  assert.equal(clones[0].value, ' ');
 });


### PR DESCRIPTION
  * use position via cursor offset in section, rather than marker
  * add section#markersFrom

A lot of small refactorings inside. Aside from using a `<br>` instead of the unprintable zero-width non-joiner space, we also return offsets from the start of the section in `cursor.offsets`

cc @mixonic 