### PR TITLE
Ensure that editor gets destroyed between tests

### DIFF
--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -98,7 +98,7 @@ test('editor parses and renders mobiledoc format', (assert) => {
 
 test('editor parses and renders html', (assert) => {
   editorElement.innerHTML = '<p>something here</p>';
-  let editor = new Editor({html: '<p>hello world</p>'});
+  editor = new Editor({html: '<p>hello world</p>'});
   editor.render(editorElement);
 
   assert.equal(editorElement.innerHTML,
@@ -107,7 +107,7 @@ test('editor parses and renders html', (assert) => {
 
 test('editor parses and renders DOM', (assert) => {
   editorElement.innerHTML = '<p>something here</p>';
-  let editor = new Editor({html: $('<p>hello world</p>')[0]});
+  editor = new Editor({html: $('<p>hello world</p>')[0]});
   editor.render(editorElement);
 
   assert.equal(editorElement.innerHTML,


### PR DESCRIPTION
cc @mixonic

These tests scoped their own `editor` variable and so the editor teardown
next happened. This leaks listeners from attached views (notably EmbedIntent).
If you click on the test page after the tests are done running you can see
EmbedIntent's click handler continuing to fire (and generating errors).