### PR TITLE
Make `disableEditing()` work before render

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -598,7 +598,9 @@ class Editor {
    */
   disableEditing() {
     this.isEditable = false;
-    this.element.setAttribute('contentEditable', false);
+    if (this.element) {
+      this.element.setAttribute('contentEditable', false);
+    }
   }
 
   /**
@@ -610,7 +612,9 @@ class Editor {
    */
   enableEditing() {
     this.isEditable = true;
-    this.element.setAttribute('contentEditable', true);
+    if (this.element) {
+      this.element.setAttribute('contentEditable', true);
+    }
   }
 
   /**

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -29,6 +29,21 @@ test('sets element as contenteditable', (assert) => {
                `editor element has a P as its first child`);
 });
 
+test('#disableEditing before render is meaningful', (assert) => {
+  let innerHTML = `<p>Hello</p>`;
+  editorElement.innerHTML = innerHTML;
+  editor = new Editor();
+  editor.disableEditing();
+  editor.render(editorElement);
+
+  assert.ok(!editorElement.hasAttribute('contenteditable'),
+            'element is not contenteditable');
+  editor.enableEditing();
+  assert.equal(editorElement.getAttribute('contenteditable'),
+               'true',
+               'element is contenteditable');
+});
+
 test('#disableEditing and #enableEditing toggle contenteditable', (assert) => {
   let innerHTML = `<p>Hello</p>`;
   editorElement.innerHTML = innerHTML;


### PR DESCRIPTION
Allow `editor.disableEditing()` to be called before the editor is rendered.