### PR TITLE
Implement Lists

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,7 @@
   "undef"         : true,     // Require all non-global variables be declared before they are used.
   "unused"        : true,     // Warn when variables are created but not used.
   "trailing"      : true,     // Prohibit trailing whitespaces.
-  "es3"           : false,     // Prohibit trailing commas for old IE 
+  "es3"           : true,     // Prohibit trailing commas for old IE 
   "esnext"        : true,     // Allow ES.next specific features such as `const` and `let`.
   
   // == Relaxing Options ================================================

--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,7 @@
   "undef"         : true,     // Require all non-global variables be declared before they are used.
   "unused"        : true,     // Warn when variables are created but not used.
   "trailing"      : true,     // Prohibit trailing whitespaces.
-  "es3"           : true,     // Prohibit trailing commas for old IE 
+  "es3"           : false,     // Prohibit trailing commas for old IE 
   "esnext"        : true,     // Allow ES.next specific features such as `const` and `let`.
   
   // == Relaxing Options ================================================

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -195,7 +195,12 @@ var ContentKitDemo = exports.ContentKitDemo = {
       'image': ContentKit.ImageCard
     };
     var renderer = new MobiledocDOMRenderer();
-    var rendered = renderer.render(mobiledoc, document.createElement('div'), cards);
+    var rendered;
+    try {
+      rendered = renderer.render(mobiledoc, document.createElement('div'), cards);
+    } catch (e) {
+      rendered = document.createTextNode('Error rendering: ' + e);
+    }
 
     $('#rendered-mobiledoc').empty();
     $('#rendered-mobiledoc')[0].appendChild(rendered);
@@ -234,7 +239,14 @@ var ContentKitDemo = exports.ContentKitDemo = {
     };
 
     var htmlRenderer = new MobiledocHTMLRenderer();
-    $('#rendered-mobiledoc-html').html(displayHTML(htmlRenderer.render(mobiledoc)));
+    var renderedHTML;
+    try {
+      renderedHTML = htmlRenderer.render(mobiledoc);
+    } catch (e) {
+      renderedHTML = 'Error rendering: ' + e;
+    }
+
+    $('#rendered-mobiledoc-html').html(displayHTML(renderedHTML));
 
     var editorHTML = debugNodeHTML($('#editor')[0]);
     $('#editor-html').html(editorHTML);
@@ -314,7 +326,7 @@ function attemptEditorReboot(editor, textPayload) {
 
 var MOBILEDOC_VERSION = "0.1";
 var sampleMobiledocs = {
-  simpleMobiledoc: {
+  xsimpleMobiledoc: {
     version: MOBILEDOC_VERSION,
     sections: [
       [],
@@ -324,6 +336,26 @@ var sampleMobiledocs = {
         ]],
         [1, "P", [
           [[], 0, "hello world"]
+        ]]
+      ]
+    ]
+  },
+
+  //simpleMobiledocWithList: {
+  simpleMobiledoc: {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [1, "H2", [
+          [[], 0, "To do today:"]
+        ]],
+        [1, "UL", [
+          [
+            [[], 0, "buy milk"],
+            [[], 0, "water cows"],
+            [[], 0, "world domination"]
+          ]
         ]]
       ]
     ]

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -326,7 +326,7 @@ function attemptEditorReboot(editor, textPayload) {
 
 var MOBILEDOC_VERSION = "0.1";
 var sampleMobiledocs = {
-  xsimpleMobiledoc: {
+  simpleMobiledoc: {
     version: MOBILEDOC_VERSION,
     sections: [
       [],
@@ -341,8 +341,7 @@ var sampleMobiledocs = {
     ]
   },
 
-  //simpleMobiledocWithList: {
-  simpleMobiledoc: {
+  simpleMobiledocWithList: {
     version: MOBILEDOC_VERSION,
     sections: [
       [],
@@ -350,12 +349,10 @@ var sampleMobiledocs = {
         [1, "H2", [
           [[], 0, "To do today:"]
         ]],
-        [1, "UL", [
-          [
-            [[], 0, "buy milk"],
-            [[], 0, "water cows"],
-            [[], 0, "world domination"]
-          ]
+        [3, 'ul', [
+          [[[], 0, 'buy milk']],
+          [[[], 0, 'water plants']],
+          [[[], 0, 'world domination']]
         ]]
       ]
     ]

--- a/demo/index.html
+++ b/demo/index.html
@@ -43,6 +43,7 @@
         <select id='select-mobiledoc'>
           <option disabled>Load a new Mobiledoc</option>
           <option value='simpleMobiledoc'>Simple text content</option>
+          <option value='simpleMobiledocWithList'>List example</option>
           <option value='mobileDocWithInputCard'>Card with Input</option>
           <option value='mobileDocWithSelfieCard'>Selfie Card</option>
         </select>

--- a/src/js/commands/image.js
+++ b/src/js/commands/image.js
@@ -13,12 +13,13 @@ export default class ImageCommand extends Command {
     let beforeSection = headMarker.section;
     let afterSection = beforeSection.next;
     let section = this.editor.builder.createCardSection('image');
+    const collection = beforeSection.parent.sections;
 
     this.editor.run((postEditor) => {
       if (beforeSection.isBlank) {
         postEditor.removeSection(beforeSection);
       }
-      postEditor.insertSectionBefore(section, afterSection);
+      postEditor.insertSectionBefore(collection, section, afterSection);
     });
   }
 }

--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -1,0 +1,36 @@
+import Section from './markup-section';
+
+export const LIST_ITEM_TYPE = 'list-item';
+
+export default class ListItem extends Section {
+  constructor(tagName, markers=[]) {
+    super(tagName, markers);
+    this.type = LIST_ITEM_TYPE;
+  }
+
+  splitAtMarker(marker, offset=0) {
+    // FIXME need to check if we are going to split into two list items
+    // or a list item and a new markup section:
+    const isLastItem = !this.next;
+    const createNewSection =
+      (marker.isEmpty && offset === 0) && isLastItem;
+
+    let [beforeSection, afterSection] = [
+      this.builder.createListItem(),
+      createNewSection ? this.builder.createMarkupSection('p') : this.builder.createListItem()
+    ];
+
+    return this._redistributeMarkers(beforeSection, afterSection, marker, offset);
+  }
+
+  splitIntoSections() {
+    return this.parent.splitAtListItem(this);
+  }
+
+  clone() {
+    const item = this.builder.createListItem();
+    this.markers.forEach(m => item.markers.append(m.clone()));
+    return item;
+  }
+}
+

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -1,0 +1,60 @@
+import Section from './markup-section';
+import LinkedList from '../utils/linked-list';
+
+export const LIST_SECTION_TYPE = 'list-section';
+
+export default class ListSection extends Section {
+  constructor(tagName, items=[]) {
+    super(tagName);
+    this.type = LIST_SECTION_TYPE;
+
+    // remove the inherited `markers` because they do nothing on a ListSection but confuse
+    this.markers = undefined;
+
+    this.items = new LinkedList({
+      adoptItem: i => i.section = i.parent = this,
+      freeItem: i => i.section = i.parent = null
+    });
+    this.sections = this.items;
+
+    items.forEach(i => this.items.append(i));
+  }
+
+  // returns [prevListSection, newMarkupSection, nextListSection]
+  // prevListSection and nextListSection may be undefined
+  splitAtListItem(listItem) {
+    if (listItem.parent !== this) {
+      throw new Error('Cannot split list section at item that is not a child');
+    }
+    const prevItem = listItem.prev,
+          nextItem = listItem.next;
+    const listSection = this;
+
+    let prevListSection, nextListSection, newSection;
+
+    newSection = this.builder.createMarkupSection('p');
+    listItem.markers.forEach(m => newSection.markers.append(m.clone()));
+
+    // If there were previous list items, add them to a new list section `prevListSection`
+    if (prevItem) {
+      prevListSection = this.builder.createListSection(this.tagName);
+      let currentItem = listSection.items.head;
+      while (currentItem !== listItem) {
+        prevListSection.items.append(currentItem.clone());
+        currentItem = currentItem.next;
+      }
+    }
+
+    // if there is a next item, add it and all after it to the `nextListSection`
+    if (nextItem) {
+      nextListSection = this.builder.createListSection(this.tagName);
+      let currentItem = nextItem;
+      while (currentItem) {
+        nextListSection.items.append(currentItem.clone());
+        currentItem = currentItem.next;
+      }
+    }
+
+    return [prevListSection, newSection, nextListSection];
+  }
+}

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -19,12 +19,11 @@ export default class Section extends LinkedItem {
   constructor(tagName, markers=[]) {
     super();
     this.markers = new LinkedList({
-      adoptItem: m => m.section = this,
-      freeItem: m => m.section = null
+      adoptItem: m => m.section = m.parent = this,
+      freeItem: m => m.section = m.parent = null
     });
     this.tagName = tagName || DEFAULT_TAG_NAME;
     this.type = MARKUP_SECTION_TYPE;
-    this.element = null;
 
     markers.forEach(m => this.markers.append(m));
   }
@@ -76,12 +75,7 @@ export default class Section extends LinkedItem {
     return newMarkers;
   }
 
-  splitAtMarker(marker, offset=0) {
-    let [beforeSection, afterSection] = [
-      this.builder.createMarkupSection(this.tagName, []),
-      this.builder.createMarkupSection(this.tagName, [])
-    ];
-
+  _redistributeMarkers(beforeSection, afterSection, marker, offset=0) {
     let currentSection = beforeSection;
     forEach(this.markers, m => {
       if (m === marker) {
@@ -98,6 +92,15 @@ export default class Section extends LinkedItem {
     afterSection.coalesceMarkers();
 
     return [beforeSection, afterSection];
+  }
+
+  splitAtMarker(marker, offset=0) {
+    let [beforeSection, afterSection] = [
+      this.builder.createMarkupSection(this.tagName, []),
+      this.builder.createMarkupSection(this.tagName, [])
+    ];
+
+    return this._redistributeMarkers(beforeSection, afterSection, marker, offset);
   }
 
   /**

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -1,5 +1,7 @@
 import Post from '../models/post';
 import MarkupSection from '../models/markup-section';
+import ListSection from '../models/list-section';
+import ListItem from '../models/list-item';
 import ImageSection from '../models/image';
 import Marker from '../models/marker';
 import Markup from '../models/markup';
@@ -37,8 +39,22 @@ export default class PostNodeBuilder {
 
   createBlankMarkupSection(tagName) {
     tagName = normalizeTagName(tagName);
-    let blankMarker = this.createBlankMarker();
+    const blankMarker = this.createBlankMarker();
     return this.createMarkupSection(tagName, [ blankMarker ]);
+  }
+
+  createListSection(tagName, items=[]) {
+    tagName = normalizeTagName(tagName);
+    const section = new ListSection(tagName, items);
+    section.builder = this;
+    return section;
+  }
+
+  createListItem(markers=[]) {
+    const tagName = normalizeTagName('li');
+    const item = new ListItem(tagName, markers);
+    item.builder = this;
+    return item;
   }
 
   createImageSection(url) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -5,8 +5,8 @@ export default class Post {
   constructor() {
     this.type = POST_TYPE;
     this.sections = new LinkedList({
-      adoptItem: s => s.post = this,
-      freeItem: s => s.post = null
+      adoptItem: s => s.post = s.parent = this,
+      freeItem: s => s.post = s.parent = null
     });
   }
 

--- a/src/js/models/render-node.js
+++ b/src/js/models/render-node.js
@@ -1,5 +1,6 @@
-import LinkedItem from "content-kit-editor/utils/linked-item";
-import LinkedList from "content-kit-editor/utils/linked-list";
+import LinkedItem from 'content-kit-editor/utils/linked-item';
+import LinkedList from 'content-kit-editor/utils/linked-list';
+import { containsNode } from 'content-kit-editor/utils/dom-utils';
 
 export default class RenderNode extends LinkedItem {
   constructor(postNode) {
@@ -10,6 +11,13 @@ export default class RenderNode extends LinkedItem {
     this.postNode = postNode;
     this._childNodes = null;
     this.element = null;
+  }
+  isAttached() {
+    const rootElement = this.renderTree.node.element;
+    if (!this.element) {
+      throw new Error('Cannot check if a renderNode is attached without an element.');
+    }
+    return containsNode(rootElement, this.element);
   }
   get childNodes() {
     if (!this._childNodes) {

--- a/src/js/renderers/mobiledoc.js
+++ b/src/js/renderers/mobiledoc.js
@@ -1,12 +1,19 @@
 import {visit, visitArray, compile} from "../utils/compiler";
 import { POST_TYPE } from "../models/post";
 import { MARKUP_SECTION_TYPE } from "../models/markup-section";
+import { LIST_SECTION_TYPE } from "../models/list-section";
+import { LIST_ITEM_TYPE } from "../models/list-item";
 import { IMAGE_SECTION_TYPE } from "../models/image";
 import { MARKER_TYPE } from "../models/marker";
 import { MARKUP_TYPE } from "../models/markup";
 import { CARD_TYPE } from "../models/card";
 
-export const MOBILEDOC_VERSION = '0.1';
+export const MOBILEDOC_VERSION = '0.2.0';
+
+export const MOBILEDOC_MARKUP_SECTION_TYPE = 1;
+export const MOBILEDOC_IMAGE_SECTION_TYPE = 2;
+export const MOBILEDOC_LIST_SECTION_TYPE = 3;
+export const MOBILEDOC_CARD_SECTION_TYPE = 10;
 
 let visitor = {
   [POST_TYPE](node, opcodes) {
@@ -15,6 +22,14 @@ let visitor = {
   },
   [MARKUP_SECTION_TYPE](node, opcodes) {
     opcodes.push(['openMarkupSection', node.tagName]);
+    visitArray(visitor, node.markers, opcodes);
+  },
+  [LIST_SECTION_TYPE](node, opcodes) {
+    opcodes.push(['openListSection', node.tagName]);
+    visitArray(visitor, node.items, opcodes);
+  },
+  [LIST_ITEM_TYPE](node, opcodes) {
+    opcodes.push(['openListItem']);
     visitArray(visitor, node.markers, opcodes);
   },
   [IMAGE_SECTION_TYPE](node, opcodes) {
@@ -43,13 +58,21 @@ let postOpcodeCompiler = {
   },
   openMarkupSection(tagName) {
     this.markers = [];
-    this.sections.push([1, tagName, this.markers]);
+    this.sections.push([MOBILEDOC_MARKUP_SECTION_TYPE, tagName, this.markers]);
+  },
+  openListSection(tagName) {
+    this.items = [];
+    this.sections.push([MOBILEDOC_LIST_SECTION_TYPE, tagName, this.items]);
+  },
+  openListItem() {
+    this.markers = [];
+    this.items.push(this.markers);
   },
   openImageSection(url) {
-    this.sections.push([2, url]);
+    this.sections.push([MOBILEDOC_IMAGE_SECTION_TYPE, url]);
   },
   openCardSection(name, payload) {
-    this.sections.push([10, name, payload]);
+    this.sections.push([MOBILEDOC_CARD_SECTION_TYPE, name, payload]);
   },
   openPost() {
     this.markerTypes = [];

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -56,10 +56,16 @@ function commonItemLength(listA, listB) {
   return offset;
 }
 
+// return new array without falsy items like ruby's `compact`
+function compact(enumerable) {
+  return filter(enumerable, i => !!i);
+}
+
 export {
   detect,
   forEach,
   any,
   filter,
-  commonItemLength
+  commonItemLength,
+  compact
 };

--- a/src/js/utils/compiler.js
+++ b/src/js/utils/compiler.js
@@ -1,5 +1,9 @@
 export function visit(visitor, node, opcodes) {
-  visitor[node.type](node, opcodes);
+  const method = node.type;
+  if (!visitor[method]) {
+    throw new Error(`Cannot visit unknown type ${method}`);
+  }
+  visitor[method](node, opcodes);
 }
 
 export function compile(compiler, opcodes) {

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -3,30 +3,10 @@ import {
   isSelectionInElement,
   clearSelection
 } from '../utils/selection-utils';
-import {
-  detectParentNode,
-  isTextNode,
-  walkDOM
-} from '../utils/dom-utils';
-import Position from "./cursor/position";
-import Range from "./cursor/range";
 
-function findOffsetInParent(parentElement, targetElement, targetOffset) {
-  let offset = 0;
-  let found = false;
-  // FIXME: would be nice to exit this walk early after we find the end node
-  walkDOM(parentElement, (childElement) => {
-    if (found) { return; }
-    found = childElement === targetElement;
-
-    if (found) {
-      offset += targetOffset;
-    } else if (isTextNode(childElement)) {
-      offset += childElement.textContent.length;
-    }
-  });
-  return offset;
-}
+import { detectParentNode } from '../utils/dom-utils';
+import Position from './cursor/position';
+import Range from './cursor/range';
 
 function findSectionContaining(sections, childNode) {
   const { result: section } = detectParentNode(childNode, node => {
@@ -80,19 +60,7 @@ export default class Cursor {
   }
 
   get sectionOffsets() {
-    const { sections } = this.post;
-    const selection = this.selection;
-    const { rangeCount } = selection;
-    const range = rangeCount > 0 && selection.getRangeAt(0);
-
-    if (!range) {
-      return {};
-    }
-
-    let {leftNode:headNode, leftOffset:headOffset} = comparePosition(selection);
-    let headSection = findSectionContaining(sections, headNode);
-    let headSectionOffset = findOffsetInParent(headSection.renderNode.element, headNode, headOffset);
-
+    const {headSection, headSectionOffset} = this.offsets;
     return {headSection, headSectionOffset};
   }
 
@@ -144,7 +112,7 @@ export default class Cursor {
 
   // moves cursor to marker
   moveToMarker(headMarker, headOffset=0, tailMarker=headMarker, tailOffset=headOffset) {
-    if (!headMarker) { throw new Error('Cannot move cursor to section without a marker'); }
+    if (!headMarker) { throw new Error('Cannot move cursor to marker without a marker'); }
     const headElement = headMarker.renderNode.element;
     const tailElement = tailMarker.renderNode.element;
 

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -1,6 +1,25 @@
 import { detect } from 'content-kit-editor/utils/array-utils';
 import { detectParentNode } from 'content-kit-editor/utils/dom-utils';
 
+// attempts to find a marker by walking up from the childNode
+// and checking to find an element in the renderTree
+// If a marker is found, return the marker's parent.
+// This ensures we get the deepest section when there are nested
+// sections (like ListItem < ListSection)
+// FIXME obviously we would like to do this more declaratively,
+// and not have two ways of finding the current focused section
+function findSectionFromRenderTree(renderTree, childNode) {
+  let currentNode = childNode;
+  while (currentNode) {
+    let renderNode = renderTree.getElementRenderNode(currentNode);
+    if (renderNode) {
+      let marker = renderNode.postNode;
+      return marker.parent;
+    }
+    currentNode = currentNode.parentNode;
+  }
+}
+
 function findSectionContaining(sections, childNode) {
   const { result: section } = detectParentNode(childNode, node => {
     return detect(sections, section => {
@@ -10,7 +29,7 @@ function findSectionContaining(sections, childNode) {
   return section;
 }
 
-export default class Position {
+const Position = class Position {
   constructor(section, offsetInSection=0) {
     let marker = null,
         offsetInMarker = null;
@@ -28,10 +47,12 @@ export default class Position {
     this.marker = marker;
     this.offsetInMarker = offsetInMarker;
   }
+
   isEqual(position) {
     return this.section === position.section &&
            this.offsetInSection === position.offsetInSection;
   }
+
   static fromNode(renderTree, sections, node, offsetInNode) {
     // Only markers are registered into the element/renderNode map
     let markerRenderNode = renderTree.getElementRenderNode(node);
@@ -49,7 +70,9 @@ export default class Position {
       // Chrome/Safari using shift+<Up arrow> can create a selection with
       // a tag rather than a text node. This fixes that.
       // See https://github.com/bustlelabs/content-kit-editor/issues/56
-      section = findSectionContaining(sections, node);
+      section = findSectionFromRenderTree(renderTree, node) ||
+        findSectionContaining(sections, node);
+
       if (section) {
         offsetInSection = 0;
       }
@@ -57,4 +80,6 @@ export default class Position {
 
     return new Position(section, offsetInSection);
   }
-}
+};
+
+export default Position;

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -1,0 +1,208 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+
+const { module, test } = Helpers;
+
+let editor, editorElement;
+
+function createEditorWithListMobiledoc() {
+  const mobiledoc = Helpers.mobiledoc.build(({post, listSection, listItem, marker}) =>
+    post([
+      listSection('ul', [
+        listItem([marker('first item')]),
+        listItem([marker('second item')])
+      ])
+    ])
+  );
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+}
+
+module('Acceptance: Editor: Lists', {
+  beforeEach() {
+    editorElement = document.createElement('div');
+    editorElement.setAttribute('id', 'editor');
+    $('#qunit-fixture').append(editorElement);
+  },
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('can type in middle of a list item', (assert) => {
+  createEditorWithListMobiledoc();
+
+  const listItem = $('#editor li:contains(first item)')[0];
+  assert.ok(!!listItem, 'precond - has li');
+
+  Helpers.dom.moveCursorTo(listItem.childNodes[0], 'first'.length);
+  Helpers.dom.insertText('X');
+
+  assert.hasElement('#editor li:contains(firstX item)', 'inserts text at right spot');
+});
+
+test('can type at end of a list item', (assert) => {
+  createEditorWithListMobiledoc();
+
+  const listItem = $('#editor li:contains(first item)')[0];
+  assert.ok(!!listItem, 'precond - has li');
+
+  Helpers.dom.moveCursorTo(listItem.childNodes[0], 'first item'.length);
+  Helpers.dom.insertText('X');
+
+  assert.hasElement('#editor li:contains(first itemX)', 'inserts text at right spot');
+});
+
+test('can type at start of a list item', (assert) => {
+  createEditorWithListMobiledoc();
+
+  const listItem = $('#editor li:contains(first item)')[0];
+  assert.ok(!!listItem, 'precond - has li');
+
+  Helpers.dom.moveCursorTo(listItem.childNodes[0], 0);
+  Helpers.dom.insertText('X');
+
+  assert.hasElement('#editor li:contains(Xfirst item)', 'inserts text at right spot');
+});
+
+test('can delete selection across list items', (assert) => {
+  createEditorWithListMobiledoc();
+
+  const listItem = $('#editor li:contains(first item)')[0];
+  assert.ok(!!listItem, 'precond - has li1');
+
+  const listItem2 = $('#editor li:contains(second item)')[0];
+  assert.ok(!!listItem2, 'precond - has li2');
+
+  Helpers.dom.selectText(' item', listItem, 'secon', listItem2);
+  Helpers.dom.triggerDelete(editor);
+
+  assert.hasElement('#editor li:contains(d item)', 'results in correct text');
+  assert.equal($('#editor li').length, 1, 'only 1 remaining li');
+});
+
+test('can exit list section altogether by deleting', (assert) => {
+  createEditorWithListMobiledoc();
+
+  const listItem2 = $('#editor li:contains(second item)')[0];
+  assert.ok(!!listItem2, 'precond - has listItem2');
+
+  Helpers.dom.moveCursorTo(listItem2.childNodes[0], 0);
+  Helpers.dom.triggerDelete(editor);
+
+  assert.hasElement('#editor li:contains(first item)', 'still has first item');
+  assert.hasNoElement('#editor li:contains(second item)', 'second li is gone');
+  assert.hasElement('#editor p:contains(second item)', 'second li becomes p');
+
+  Helpers.dom.insertText('X');
+  
+  assert.hasElement('#editor p:contains(Xsecond item)', 'new text is in right spot');
+});
+
+test('can split list item with <enter>', (assert) => {
+  createEditorWithListMobiledoc();
+
+  let li = $('#editor li:contains(first item)')[0];
+  assert.ok(!!li, 'precond');
+
+  Helpers.dom.moveCursorTo(li.childNodes[0], 'fir'.length);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.hasNoElement('#editor li:contains(first item)', 'first item is split');
+  assert.hasElement('#editor li:contains(fir)', 'has split "fir" li');
+  assert.hasElement('#editor li:contains(st item)', 'has split "st item" li');
+  assert.hasElement('#editor li:contains(second item)', 'has unchanged last li');
+  assert.equal($('#editor li').length, 3, 'has 3 lis');
+
+  // hitting enter can create the right DOM but put the AT out of sync with the
+  // renderTree, so we must hit enter once more to fully test this
+
+  li = $('#editor li:contains(fir)')[0];
+  assert.ok(!!li, 'precond - has "fir"');
+  Helpers.dom.moveCursorTo(li.childNodes[0], 'fi'.length);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.hasNoElement('#editor li:contains(fir)');
+  assert.hasElement('#editor li:contains(fi)', 'has split "fi" li');
+  assert.hasElement('#editor li:contains(r)', 'has split "r" li');
+  assert.equal($('#editor li').length, 4, 'has 4 lis');
+});
+
+test('can hit enter at end of list item to add new item', (assert) => {
+  createEditorWithListMobiledoc();
+
+  const li = $('#editor li:contains(first item)')[0];
+  assert.ok(!!li, 'precond');
+
+  Helpers.dom.moveCursorTo(li.childNodes[0], 'first item'.length);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, 3, 'adds a new li');
+  let newLi = $('#editor li:eq(1)');
+  assert.equal(newLi.text(), '', 'new li has no text');
+
+  Helpers.dom.insertText('X');
+  assert.hasElement('#editor li:contains(X)', 'text goes in right spot');
+
+  const liCount = $('#editor li').length;
+  Helpers.dom.triggerEnter(editor);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, liCount+2, 'adds two new empty list items');
+});
+
+test('hitting enter to add list item, deleting to remove it, adding new list item, exiting list and typing', (assert) => {
+  createEditorWithListMobiledoc();
+
+  let li = $('#editor li:contains(first item)')[0];
+  assert.ok(!!li, 'precond');
+
+  Helpers.dom.moveCursorTo(li.childNodes[0], 'first item'.length);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, 3, 'adds a new li');
+
+  Helpers.dom.triggerDelete(editor);
+
+  assert.equal($('#editor li').length, 2, 'removes middle, empty li after delete');
+  assert.equal($('#editor p').length, 1, 'adds a new paragraph section where delete happened');
+
+  li = $('#editor li:contains(first item)')[0];
+  Helpers.dom.moveCursorTo(li.childNodes[0], 'first item'.length);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, 3, 'adds a new li after enter again');
+
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, 2, 'removes newly added li after enter on last list item');
+  assert.equal($('#editor p').length, 2, 'adds a second p section');
+
+  Helpers.dom.insertText('X');
+
+  assert.hasElement('#editor p:eq(0):contains(X)', 'inserts text in right spot');
+});
+
+test('hitting enter at empty last list item exists list', (assert) => {
+  createEditorWithListMobiledoc();
+
+  assert.equal($('#editor p').length, 0, 'precond - no ps');
+
+  const li = $('#editor li:contains(second item)')[0];
+  assert.ok(!!li, 'precond');
+
+  Helpers.dom.moveCursorTo(li.childNodes[0], 'second item'.length);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, 3, 'precond - adds a third li');
+
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor li').length, 2, 'removes empty li');
+  assert.equal($('#editor p').length, 1, 'adds 1 new p');
+  assert.equal($('#editor p').text(), '', 'p has no text');
+
+  Helpers.dom.insertText('X');
+  assert.hasElement('#editor p:contains(X)', 'text goes in right spot');
+});

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -3,7 +3,7 @@ import Helpers from '../test-helpers';
 import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
 import { NO_BREAK_SPACE } from 'content-kit-editor/renderers/editor-dom';
 
-const { test, module } = QUnit;
+const { test, module } = Helpers;
 
 let fixture, editor, editorElement;
 const mobileDocWith1Section = {
@@ -282,28 +282,33 @@ test('keystroke of delete when cursor is after only char in only marker of secti
   assert.hasElement('#editor p:eq(0):contains(X)', 'text is added back to section');
 });
 
-Helpers.skipInPhantom('keystroke of character in empty section adds character, moves cursor', (assert) => {
+test('keystroke of character in empty section adds character, moves cursor', (assert) => {
   editor = new Editor({mobiledoc: mobileDocWithNoCharacter});
   editor.render(editorElement);
   const getTextNode = () => editor.element.
-                                  firstChild. // section
-                                  firstChild; // marker
+                                  childNodes[0]. // section
+                                  childNodes[0]; // marker
 
   let textNode = getTextNode();
   assert.ok(!!textNode, 'precond - gets text node');
   Helpers.dom.moveCursorTo(textNode, 0);
 
-  const key = "M";
-  const keyCode = key.charCodeAt(0);
-  Helpers.dom.triggerKeyEvent(document, 'keydown', keyCode, key);
+  const letter = 'M';
+  Helpers.dom.insertText(letter);
 
-  textNode = getTextNode();
-  assert.equal(textNode.textContent, key, 'adds character');
-  assert.equal(textNode.textContent.length, 1);
+  assert.equal(getTextNode().textContent, letter, 'adds character');
+  assert.equal(getTextNode().textContent.length, 1);
 
   assert.deepEqual(Helpers.dom.getCursorPosition(),
-                  {node: textNode, offset: 1},
-                  `cursor moves to end of ${key} text node`);
+                  {node: getTextNode(), offset: 1},
+                  `cursor moves to end of ${letter} text node`);
+
+  const otherLetter = 'X';
+  Helpers.dom.insertText(otherLetter);
+
+  assert.equal(getTextNode().textContent, `${letter}${otherLetter}`,
+               'adds character in the correct spot');
+  assert.equal(getTextNode().textContent.length, letter.length + otherLetter.length);
 });
 
 test('keystroke of delete at start of section joins with previous section', (assert) => {

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -96,7 +96,7 @@ _buildDOM.text = (string) => {
 
 /**
  * Usage:
- * makeDOM(t =>
+ * build(t =>
  *   t('div', attributes={}, children=[
  *     t('b', {}, [
  *       t.text('I am a bold text node')
@@ -104,7 +104,7 @@ _buildDOM.text = (string) => {
  *   ])
  * );
  */
-function makeDOM(tree) {
+function build(tree) {
   return tree(_buildDOM);
 }
 
@@ -140,6 +140,7 @@ function getCursorPosition() {
 }
 
 function triggerDelete(editor) {
+  if (!editor) { throw new Error('Must pass `editor` to `triggerDelete`'); }
   if (isPhantom()) {
     // simulate deletion for phantomjs
     let event = { preventDefault() {} };
@@ -150,6 +151,7 @@ function triggerDelete(editor) {
 }
 
 function triggerEnter(editor) {
+  if (!editor) { throw new Error('Must pass `editor` to `triggerEnter`'); }
   if (isPhantom()) {
     // simulate event when testing with phantom
     let event = { preventDefault() {} };
@@ -169,7 +171,7 @@ const DOMHelper = {
   clearSelection,
   triggerEvent,
   triggerKeyEvent,
-  makeDOM,
+  build,
   KEY_CODES,
   getCursorPosition,
   getSelectedText,

--- a/tests/helpers/mobiledoc.js
+++ b/tests/helpers/mobiledoc.js
@@ -3,7 +3,7 @@ import MobiledocRenderer from 'content-kit-editor/renderers/mobiledoc';
 
 /*
  * usage:
- *  makeMD(({post, section, marker, markup}) =>
+ *  build(({post, section, marker, markup}) =>
  *    post([
  *      section('P', [
  *        marker('some text', [markup('B')])

--- a/tests/helpers/post-abstract.js
+++ b/tests/helpers/post-abstract.js
@@ -13,12 +13,16 @@ import PostNodeBuilder from 'content-kit-editor/models/post-node-builder';
 function build(treeFn) {
   let builder = new PostNodeBuilder();
 
-  const post          = (...args) => builder.createPost(...args);
-  const markupSection = (...args) => builder.createMarkupSection(...args);
-  const markup        = (...args) => builder.createMarkup(...args);
-  const marker        = (...args) => builder.createMarker(...args);
+  const simpleBuilder = {
+    post          : (...args) => builder.createPost(...args),
+    markupSection : (...args) => builder.createMarkupSection(...args),
+    markup        : (...args) => builder.createMarkup(...args),
+    marker        : (...args) => builder.createMarker(...args),
+    listSection   : (...args) => builder.createListSection(...args),
+    listItem      : (...args) => builder.createListItem(...args)
+  };
 
-  return treeFn({post, markupSection, markup, marker});
+  return treeFn(simpleBuilder);
 }
 
 export default {

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -7,7 +7,24 @@ import skipInPhantom from './helpers/skip-in-phantom';
 import MobiledocHelpers from './helpers/mobiledoc';
 import PostAbstract from './helpers/post-abstract';
 
-const { test } = QUnit;
+const { test:qunitTest, module } = QUnit;
+
+QUnit.config.urlConfig.push({
+  id: 'debugTest',
+  label: 'Debug Test'
+});
+
+const test = (msg, callback) => {
+  let originalCallback = callback;
+  callback = (...args) => {
+    if (QUnit.config.debugTest) {
+      debugger; // jshint ignore:line
+    }
+    originalCallback(...args);
+  };
+  qunitTest(msg, callback);
+};
+
 function skip(message) {
   message = `[SKIPPED] ${message}`;
   test(message, (assert) => assert.ok(true));
@@ -19,5 +36,7 @@ export default {
   skipInPhantom,
   mobiledoc: MobiledocHelpers,
   postAbstract: PostAbstract,
-  skip
+  skip,
+  test,
+  module
 };

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -8,7 +8,7 @@ const { module, test } = window.QUnit;
 let fixture, editorElement, editor;
 
 module('Unit: Editor', {
-  beforeEach: function() {
+  beforeEach() {
     fixture = document.getElementById('qunit-fixture');
     editorElement = document.createElement('div');
     editorElement.id = 'editor1';

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -151,3 +151,31 @@ test('#parse doc with custom card type', (assert) => {
     post
   );
 });
+
+test('#parse a mobile doc with list-section and list-item', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [3, 'ul', [
+          [[[], 0, "first item"]],
+          [[[], 0, "second item"]]
+        ]]
+      ]
+    ]
+  };
+
+  const parsed = parser.parse(mobiledoc);
+
+  const items = [
+    builder.createListItem([builder.createMarker('first item')]),
+    builder.createListItem([builder.createMarker('second item')])
+  ];
+  const section = builder.createListSection('ul', items);
+  post.sections.append(section);
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -17,7 +17,7 @@ module('Unit: Parser: SectionParser', {
 });
 
 test('#parse parses simple dom', (assert) => {
-  let element = Helpers.dom.makeDOM(t =>
+  let element = Helpers.dom.build(t =>
     t('p', {}, [
       t.text('hello there'),
       t('b', {}, [
@@ -37,7 +37,7 @@ test('#parse parses simple dom', (assert) => {
 });
 
 test('#parse parses nested markups', (assert) => {
-  let element = Helpers.dom.makeDOM(t =>
+  let element = Helpers.dom.build(t =>
     t('p', {}, [
       t('b', {}, [
         t.text('i am bold'),
@@ -63,7 +63,7 @@ test('#parse parses nested markups', (assert) => {
 });
 
 test('#parse ignores non-markup elements like spans', (assert) => {
-  let element = Helpers.dom.makeDOM(t =>
+  let element = Helpers.dom.build(t =>
     t('p', {}, [
       t('span', {}, [
         t.text('i was in span')
@@ -80,7 +80,7 @@ test('#parse ignores non-markup elements like spans', (assert) => {
 });
 
 test('#parse reads attributes', (assert) => {
-  let element = Helpers.dom.makeDOM(t =>
+  let element = Helpers.dom.build(t =>
     t('p', {}, [
       t('a', {href: 'google.com'}, [
         t.text('i am a link')
@@ -96,7 +96,7 @@ test('#parse reads attributes', (assert) => {
 });
 
 test('#parse joins contiguous text nodes separated by non-markup elements', (assert) => {
-  let element = Helpers.dom.makeDOM(t =>
+  let element = Helpers.dom.build(t =>
     t('p', {}, [
       t('span', {}, [
         t.text('span 1')

--- a/tests/unit/renderers/mobiledoc-test.js
+++ b/tests/unit/renderers/mobiledoc-test.js
@@ -134,3 +134,26 @@ test('renders a post with card', (assert) => {
     ]
   });
 });
+
+test('renders a post with a list', (assert) => {
+  const items = [
+    builder.createListItem([builder.createMarker('first item')]),
+    builder.createListItem([builder.createMarker('second item')])
+  ];
+  const section = builder.createListSection('ul', items);
+  const post = builder.createPost([section]);
+
+  const mobiledoc = render(post);
+  assert.deepEqual(mobiledoc, {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [3, 'ul', [
+          [[[], 0, 'first item']],
+          [[[], 0, 'second item']]
+        ]]
+      ]
+    ]
+  });
+});


### PR DESCRIPTION
*ready to merge*

fixes #86 

This adds a:
  * `ListSection` — inherits from `MarkupSection` and lives alongside `MarkupSection`s and cards in the post's `sections` list
  * `ListItem` — inherits from `MarkupSection` and lives in the nested `items`/`sections` list on a `ListSection`, has a list of `markers`
  * Some edge case code to `postEditor#splitSection` to deal with hitting enter on an empty final list item
  * Some largely duplicated code in `ListItem#splitAtMarker` that could be cleaned up
  * Simplifies `editor#reparse` by recognizing that there are fewer unexpected situations that could occur
  * Add a new type of section ("3") to mobiledoc format for lists
  * Update the Mobiledoc renderer to render ListSections and ListItems
  * Update the EditorDom renderer to render ListSections and ListItems
  * Update MOBILEDOC_VERSION to "0.2.0"

Stil to do:
  * [ ] update the mobiledoc html/dom renderers to recognize the change to the mobiledoc format ([dom](https://github.com/bustlelabs/mobiledoc-dom-renderer/issues/4) and [html](https://github.com/bustlelabs/mobiledoc-html-renderer/issues/4))
  * [x] clean up duplicated code
  * [x] there are still some slightly buggy behaviors around adding multiple list items, apply markup across list items, etc. Corral these