### PR TITLE
Introduce lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,44 @@ editor.render(element);
 * `editor.enableEditing()` - allow the user to make direct edits directly
   to a post's text.
 
+### Editor Lifecycle Hooks
+
+API consumers may want to react to given interaction by the user (or by
+a programmatic edit of the post). Lifecyle hooks provide notification
+of change and opportunity to edit the post where appropriate.
+
+Register a lifecycle hook by calling the hook name on the editor with a
+callback function. For example:
+
+```js
+editor.didUpdatePost(postEditor => {
+  let { offsets } = editor.offsets,
+      cursorSection;
+
+  if (offset.headSection.text === 'add-section-when-i-type-this') {
+    let section = editor.builder.createMarkupSection('p');
+    postEditor.insertSectionBefore(section, cursorSection.next);
+    cursorSection = section;
+  }
+
+  postEditor.scheduleRerender();
+  postEditor.schedule(() => {
+    if (cursorSection) {
+      editor.moveToSection(cursorSection, 0);
+    }
+  });
+});
+```
+
+The available lifecycle hooks are:
+
+* `editor.didUpdatePost(postEditor => {})` - An opprotunity to use the
+  `postEditor` and possibly change the post before rendering begins.
+* `editor.willRender()` - After all post mutation has finished, but before
+   the DOM is updated.
+* `editor.didRender()` - After the DOM has been updated to match the
+  edited post.
+
 ### Programmatic Post Editing
 
 A major goal of Content-Kit is to allow complete customization of user

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -297,7 +297,7 @@ function bootEditor(element, mobiledoc) {
     ContentKitDemo.syncCodePane(editor);
   }
 
-  editor.on('update', sync);
+  editor.willRender(sync);
   sync();
 }
 

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -58,6 +58,75 @@ test('rendering an editor adds EDITOR_ELEMENT_CLASS_NAME if not there', (assert)
   assert.ok(hasClass('abc') && hasClass('def'), 'preserves existing class names');
 });
 
+test('editor fires lifecycle hooks', (assert) => {
+  assert.expect(4);
+  let didCallUpdatePost, didCallWillRender, didCallDidRender;
+  editor = new Editor();
+  editor.didUpdatePost(postEditor => {
+    assert.ok(postEditor, 'Post editor provided');
+    assert.ok(!didCallWillRender && !didCallDidRender,
+              'didUpdatePost called before render hooks');
+    didCallUpdatePost = true;
+  });
+  editor.willRender(() => {
+    assert.ok(didCallUpdatePost && !didCallDidRender,
+              'willRender called between didUpdatePost, didRender');
+    didCallWillRender = true;
+  });
+  editor.didRender(() => {
+    assert.ok(didCallUpdatePost && didCallWillRender,
+              'didRender called last');
+    didCallDidRender = true;
+  });
+  editor.render(editorElement);
+});
+
+test('editor fires lifecycle hooks for edit', (assert) => {
+  assert.expect(4);
+  editor = new Editor();
+  editor.render(editorElement);
+
+  let didCallUpdatePost, didCallWillRender, didCallDidRender;
+  editor.didUpdatePost(postEditor => {
+    assert.ok(postEditor, 'Post editor provided');
+    assert.ok(!didCallWillRender && !didCallDidRender,
+              'didUpdatePost called before render hooks');
+    didCallUpdatePost = true;
+  });
+  editor.willRender(() => {
+    assert.ok(didCallUpdatePost && !didCallDidRender,
+              'willRender called between didUpdatePost, didRender');
+    didCallWillRender = true;
+  });
+  editor.didRender(() => {
+    assert.ok(didCallUpdatePost && didCallWillRender,
+              'didRender called last');
+    didCallDidRender = true;
+  });
+
+  editor.run(postEditor => {
+    postEditor.removeSection(editor.post.sections.head);
+  });
+});
+
+test('editor fires lifecycle hooks for noop edit', (assert) => {
+  assert.expect(1);
+  editor = new Editor();
+  editor.render(editorElement);
+
+  editor.didUpdatePost(postEditor => {
+    assert.ok(postEditor, 'Post editor provided');
+  });
+  editor.willRender(() => {
+    assert.ok(false, 'willRender should not be called');
+  });
+  editor.didRender(() => {
+    assert.ok(false, 'didRender should not be called');
+  });
+
+  editor.run(() => {});
+});
+
 test('editor fires update event', (assert) => {
   assert.expect(2);
   let done = assert.async();


### PR DESCRIPTION
* didUpdatePost, which gets passed the postEditor
* willRender, before render after post changes are complete
* didRender, after render when DOM and post are in sync

TODO:

* [x] Docs