### PR TITLE
Drop all blank markers, section renders br

### DIFF
--- a/src/js/commands/image.js
+++ b/src/js/commands/image.js
@@ -9,8 +9,7 @@ export default class ImageCommand extends Command {
   }
 
   exec() {
-    let {headMarker} = this.editor.cursor.offsets;
-    let beforeSection = headMarker.section;
+    let {headSection: beforeSection} = this.editor.cursor.offsets;
     let afterSection = beforeSection.next;
     let section = this.editor.builder.createCardSection('image');
     const collection = beforeSection.parent.sections;

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -338,14 +338,14 @@ class Editor {
       this.cursor.moveToSection(offsets.headSection, offsets.headSectionOffset);
     } else {
       let results = this.run(postEditor => {
-        const {headMarker, headMarkerOffset} = offsets;
+        const {headSection, headSectionOffset} = offsets;
         const key = Key.fromEvent(event);
 
-        const deletePosition = {marker: headMarker, offset: headMarkerOffset},
+        const deletePosition = {section: headSection, offset: headSectionOffset},
               direction = key.direction;
         return postEditor.deleteFrom(deletePosition, direction);
       });
-      this.cursor.moveToMarker(results.currentMarker, results.currentOffset);
+      this.cursor.moveToSection(results.currentSection, results.currentOffset);
     }
   }
 
@@ -364,6 +364,10 @@ class Editor {
     this.run((postEditor) => {
       if (this.cursor.hasSelection()) {
         postEditor.deleteRange(offsets);
+        if (offsets.headSection.isBlank) {
+          cursorSection = offsets.headSection;
+          return;
+        }
       }
       cursorSection = postEditor.splitSection(offsets)[1];
     });

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -221,14 +221,22 @@ class PostEditor {
         return this._deleteForwardFrom(result);
       }
     } else {
-      if (direction === DIRECTION.BACKWARD && section.prev) {
-        let prevSection = section.prev;
-        prevSection.join(section);
-        prevSection.renderNode.markDirty();
-        this.removeSection(section);
-        this.scheduleRerender();
-        this.scheduleDidUpdate();
-        return { currentSection: prevSection, currentOffset: prevSection.text.length };
+      if (direction === DIRECTION.BACKWARD) {
+        if (isMarkupSection(section) && section.prev) {
+          let prevSection = section.prev;
+          prevSection.join(section);
+          prevSection.renderNode.markDirty();
+          this.removeSection(section);
+          this.scheduleRerender();
+          this.scheduleDidUpdate();
+          return { currentSection: prevSection, currentOffset: prevSection.text.length };
+        } else if (isListItem(section)) {
+          this.scheduleRerender();
+          this.scheduleDidUpdate();
+
+          const results = this._convertListItemToMarkupSection(section);
+          return {currentSection: results.section, currentOffset: results.offset};
+        }
       } else if (section.prev || section.next) {
         let nextSection = section.next || section.post.tail;
         this.removeSection(section);

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -48,7 +48,7 @@ class PostEditor {
    *
    * @method deleteRange
    * @param {Object} markerRange Object with offsets, {headSection, headSectionOffset, tailSection, tailSectionOffset}
-   * @return {Object} {currentMarker, currentOffset} for cursor
+   * @return {Object} {currentSection, currentOffset} for cursor
    * @public
    */
   deleteRange(markerRange) {
@@ -85,6 +85,7 @@ class PostEditor {
             tailSection.markersFor(tailSectionOffset, section.text.length).forEach(m => {
               headSection.markers.append(m);
             });
+            headSection.renderNode.markDirty(); // May have added nodes
             removedSections.push(tailSection);
             break;
           default:
@@ -101,32 +102,88 @@ class PostEditor {
   }
 
   cutSection(section, headSectionOffset, tailSectionOffset) {
-    const {marker:headMarker, offset:headMarkerOffset} = section.markerPositionAtOffset(headSectionOffset);
-    const {marker:tailMarker, offset:tailMarkerOffset} = section.markerPositionAtOffset(tailSectionOffset);
-    const markers = this.splitMarkers({headMarker, headMarkerOffset, tailMarker, tailMarkerOffset});
-    section.markers.removeBy(m => {
-      return markers.indexOf(m) !== -1;
-    });
+    if (section.markers.isEmpty) {
+      return;
+    }
+
+    let adjustedHead = 0,
+        marker = section.markers.head,
+        adjustedTail = marker.length;
+
+    // Walk to the first node inside the headSectionOffset, splitting
+    // a marker if needed. Leave marker as the first node inside.
+    while (marker) {
+      if (adjustedTail >= headSectionOffset) {
+        let splitOffset = headSectionOffset - adjustedHead;
+        let { afterMarker } = this.splitMarker(marker, splitOffset);
+        adjustedHead = adjustedHead + splitOffset;
+        // FIXME: That these two loops cannot agree on adjustedTail being
+        // incremented at the start or end seems prime for refactoring.
+        adjustedTail = adjustedHead;
+        marker = afterMarker;
+        break;
+      }
+      adjustedHead += marker.length;
+      marker = marker.next;
+      if (marker) {
+        adjustedTail += marker.length;
+      }
+    }
+
+    // Walk each marker inside, removing it if needed. when the last is
+    // reached split it and remove the part inside the tailSectionOffset
+    while (marker) {
+      adjustedTail += marker.length;
+      if (adjustedTail >= tailSectionOffset) {
+        let splitOffset = marker.length - (adjustedTail - tailSectionOffset);
+        let {
+          beforeMarker
+        } = this.splitMarker(marker, splitOffset);
+        if (beforeMarker) {
+          this.removeMarker(beforeMarker);
+        }
+        break;
+      }
+      adjustedHead += marker.length;
+      let nextMarker = marker.next;
+      this.removeMarker(marker);
+      marker = nextMarker;
+    }
+  }
+
+  removeMarkerRange(headMarker, tailMarker) {
+    let marker = headMarker;
+    while (marker) {
+      let nextMarker = marker.next;
+      this.removeMarker(marker);
+      if (marker === tailMarker) {
+        break;
+      }
+      marker = nextMarker;
+    }
   }
 
   _coalesceMarkers(section) {
-    filter(section.markers, m => m.isEmpty).forEach(m => {
-      this.removeMarker(m);
+    filter(section.markers, m => m.isEmpty).forEach(marker => {
+      this.removeMarker(marker);
     });
-    if (section.markers.isEmpty) {
-      section.markers.append(this.builder.createBlankMarker());
-      section.renderNode.markDirty();
-    }
   }
 
   removeMarker(marker) {
+    let didChange = false;
     if (marker.renderNode) {
       marker.renderNode.scheduleForRemoval();
+      didChange = true;
     }
-    marker.section.markers.remove(marker);
+    if (marker.section) {
+      marker.section.markers.remove(marker);
+      didChange = true;
+    }
 
-    this.scheduleRerender();
-    this.scheduleDidUpdate();
+    if (didChange) {
+      this.scheduleRerender();
+      this.scheduleDidUpdate();
+    }
   }
 
   /**
@@ -138,7 +195,7 @@ class PostEditor {
    *     let marker = editor.post.sections.head.markers.head;
    *     // marker has text of "Howdy!"
    *     editor.run((postEditor) => {
-   *       postEditor.deleteFrom({marker, offset: 3});
+   *       postEditor.deleteFrom({section, offset: 3});
    *     });
    *     // marker has text of "Hody!"
    *
@@ -149,16 +206,34 @@ class PostEditor {
    * marker.
    *
    * @method deleteFrom
-   * @param {Object} position object with {marker, offset} the marker and offset to delete from
+   * @param {Object} position object with {section, offset} the marker and offset to delete from
    * @param {Number} direction The direction to delete in (default is BACKWARD)
-   * @return {Object} {currentMarker, currentOffset} for positioning the cursor
+   * @return {Object} {currentSection, currentOffset} for positioning the cursor
    * @public
    */
-  deleteFrom({marker, offset}, direction=DIRECTION.BACKWARD) {
-    if (direction === DIRECTION.BACKWARD) {
-      return this._deleteBackwardFrom({marker, offset});
+  deleteFrom({section, offset}, direction=DIRECTION.BACKWARD) {
+    if (section.markers.length) {
+      // {{marker, offset}}
+      let result = section.markerPositionAtOffset(offset);
+      if (direction === DIRECTION.BACKWARD) {
+        return this._deleteBackwardFrom(result);
+      } else {
+        return this._deleteForwardFrom(result);
+      }
     } else {
-      return this._deleteForwardFrom({marker, offset});
+      if (direction === DIRECTION.BACKWARD && section.prev) {
+        let prevSection = section.prev;
+        prevSection.join(section);
+        prevSection.renderNode.markDirty();
+        this.removeSection(section);
+        this.scheduleRerender();
+        this.scheduleDidUpdate();
+        return { currentSection: prevSection, currentOffset: prevSection.text.length };
+      } else if (section.prev || section.next) {
+        let nextSection = section.next || section.post.tail;
+        this.removeSection(section);
+        return { currentSection: nextSection, currentOffset: 0 };
+      }
     }
   }
 
@@ -168,8 +243,8 @@ class PostEditor {
    * @private
    */
   _deleteForwardFrom({marker, offset}) {
-    const nextCursorMarker = marker,
-          nextCursorOffset = offset;
+    const nextCursorSection = marker.section,
+          nextCursorOffset = marker.offsetInParent(offset);
 
     if (offset === marker.length) {
       const nextMarker = marker.next;
@@ -182,21 +257,22 @@ class PostEditor {
           const currentSection = marker.section;
 
           currentSection.join(nextSection);
-
           currentSection.renderNode.markDirty();
-          nextSection.renderNode.scheduleForRemoval();
+
+          this.removeSection(nextSection);
         }
       }
     } else {
       marker.deleteValueAtOffset(offset);
       marker.renderNode.markDirty();
+      this._coalesceMarkers(marker.section);
     }
 
     this.scheduleRerender();
     this.scheduleDidUpdate();
 
     return {
-      currentMarker: nextCursorMarker,
+      currentSection: nextCursorSection,
       currentOffset: nextCursorOffset
     };
   }
@@ -209,7 +285,10 @@ class PostEditor {
 
     this._replaceSection(listSection, compact(newSections));
 
-    const newCursorPosition = {marker: newMarkupSection.markers.head, offset: 0};
+    const newCursorPosition = {
+      section: newMarkupSection,
+      offset: 0
+    };
     return newCursorPosition;
   }
 
@@ -219,8 +298,8 @@ class PostEditor {
    * @private
    */
   _deleteBackwardFrom({marker, offset}) {
-    let nextCursorMarker = marker,
-        nextCursorOffset = offset;
+    let nextCursorSection = marker.section,
+        nextCursorOffset = marker.offsetInParent(offset);
 
     if (offset === 0) {
       const prevMarker = marker.prev;
@@ -232,23 +311,25 @@ class PostEditor {
 
         if (isListItem(section)) {
           const newCursorPos = this._convertListItemToMarkupSection(section);
-          nextCursorMarker = newCursorPos.marker;
+          nextCursorSection = newCursorPos.section;
           nextCursorOffset = newCursorPos.offset;
         } else {
           const prevSection = section.prev;
           if (prevSection && isMarkupSection(prevSection)) {
-            nextCursorMarker = prevSection.markers.tail;
-            nextCursorOffset = nextCursorMarker.length;
+            nextCursorSection = prevSection;
+            nextCursorOffset = prevSection.text.length;
 
-            let { beforeMarker, afterMarker } = prevSection.join(marker.section);
+            let {
+              beforeMarker
+            } = prevSection.join(marker.section);
             prevSection.renderNode.markDirty();
-            marker.section.renderNode.scheduleForRemoval();
+            this.removeSection(marker.section);
+
+            nextCursorSection = prevSection;
 
             if (beforeMarker) {
-              nextCursorMarker = beforeMarker;
-              nextCursorOffset = beforeMarker.length;
+              nextCursorOffset = beforeMarker.offsetInParent(beforeMarker.length);
             } else {
-              nextCursorMarker = afterMarker;
               nextCursorOffset = 0;
             }
           }
@@ -257,28 +338,17 @@ class PostEditor {
 
     } else if (offset <= marker.length) {
       const offsetToDeleteAt = offset - 1;
-
       marker.deleteValueAtOffset(offsetToDeleteAt);
-
-      if (marker.isEmpty && marker.prev) {
-        marker.renderNode.scheduleForRemoval();
-        nextCursorMarker = marker.prev;
-        nextCursorOffset = nextCursorMarker.length;
-      } else if (marker.isEmpty && marker.next) {
-        marker.renderNode.scheduleForRemoval();
-        nextCursorMarker = marker.next;
-        nextCursorOffset = 0;
-      } else {
-        marker.renderNode.markDirty();
-        nextCursorOffset = offsetToDeleteAt;
-      }
+      nextCursorOffset--;
+      marker.renderNode.markDirty();
+      this._coalesceMarkers(marker.section);
     }
 
     this.scheduleRerender();
     this.scheduleDidUpdate();
 
     return {
-      currentMarker: nextCursorMarker,
+      currentSection: nextCursorSection,
       currentOffset: nextCursorOffset
     };
   }
@@ -366,6 +436,33 @@ class PostEditor {
     return selectedMarkers;
   }
 
+  splitMarker(marker, offset) {
+    let beforeMarker, afterMarker;
+
+    if (offset === 0) {
+      beforeMarker = marker.prev;
+      afterMarker = marker;
+    } else if (offset === marker.length) {
+      beforeMarker = marker;
+      afterMarker = marker.next;
+    } else {
+      let { builder } = this.editor,
+          { section } = marker;
+      beforeMarker = builder.createMarker(marker.value.substring(0, offset), marker.markups);
+      afterMarker = builder.createMarker(marker.value.substring(offset, marker.length), marker.markups);
+      section.markers.splice(marker, 1, [beforeMarker, afterMarker]);
+      if (marker.renderNode) {
+        marker.renderNode.scheduleForRemoval();
+      }
+      if (section.renderNode) {
+        section.renderNode.markDirty();
+      }
+    }
+    this.scheduleRerender();
+    this.scheduleDidUpdate();
+    return { beforeMarker, afterMarker };
+  }
+
   /**
    * Split a section at one position. This method is designed to accept
    * `editor.cursor.offsets` as an argument, but will only split at the
@@ -400,6 +497,8 @@ class PostEditor {
     } = section.markerPositionAtOffset(headSectionOffset);
 
     const [beforeSection, afterSection] = section.splitAtMarker(headMarker, headMarkerOffset);
+    this._coalesceMarkers(beforeSection);
+    this._coalesceMarkers(afterSection);
 
     const newSections = [beforeSection, afterSection];
     let replacementSections = [beforeSection, afterSection];

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -1,0 +1,136 @@
+import { normalizeTagName } from '../utils/dom-utils';
+import { forEach, filter, reduce } from '../utils/array-utils';
+
+import LinkedItem from '../utils/linked-item';
+import LinkedList from '../utils/linked-list';
+
+export default class Markerable extends LinkedItem {
+  constructor(tagName, markers=[]) {
+    super();
+    this.tagName = tagName;
+    this.markers = new LinkedList({
+      adoptItem: m => m.section = m.parent = this,
+      freeItem: m => m.section = m.parent = null
+    });
+
+    markers.forEach(m => this.markers.append(m));
+  }
+
+  set tagName(val) {
+    this._tagName = normalizeTagName(val);
+  }
+
+  get tagName() {
+    return this._tagName;
+  }
+
+  get isBlank() {
+    if (!this.markers.length) {
+      return true;
+    }
+    let markerWithLength = this.markers.detect((marker) => {
+      return !!marker.length;
+    });
+    return !markerWithLength;
+  }
+
+  /**
+   * Splits the marker at the offset, filters empty markers from the result,
+   * and replaces this marker with the new non-empty ones
+   * @param {Marker} marker the marker to split
+   * @return {Array} the new markers that replaced `marker`
+   */
+  splitMarker(marker, offset, endOffset=marker.length) {
+    const newMarkers = filter(marker.split(offset, endOffset), m => !m.isEmpty);
+    this.markers.splice(marker, 1, newMarkers);
+    if (this.markers.length === 0) {
+      let blankMarker = this.builder.createBlankMarker();
+      this.markers.append(blankMarker);
+      newMarkers.push(blankMarker);
+    }
+    return newMarkers;
+  }
+
+  // puts clones of this.markers into beforeSection and afterSection,
+  // all markers before the marker/offset split go in beforeSection, and all
+  // after the marker/offset split go in afterSection
+  // @return {Array} [beforeSection, afterSection], two new sections
+  _redistributeMarkers(beforeSection, afterSection, marker, offset=0) {
+    let currentSection = beforeSection;
+    forEach(this.markers, m => {
+      if (m === marker) {
+        const [beforeMarker, ...afterMarkers] = marker.split(offset);
+        beforeSection.markers.append(beforeMarker);
+        forEach(afterMarkers, _m => afterSection.markers.append(_m));
+        currentSection = afterSection;
+      } else {
+        currentSection.markers.append(m.clone());
+      }
+    });
+
+    return [beforeSection, afterSection];
+  }
+
+  splitAtMarker(/*marker, offset=0*/) {
+    throw new Error('splitAtMarker must be implemented by sub-class');
+  }
+
+  markerPositionAtOffset(offset) {
+    let currentOffset = 0;
+    let currentMarker;
+    let remaining = offset;
+    this.markers.detect((marker) => {
+      currentOffset = Math.min(remaining, marker.length);
+      remaining -= currentOffset;
+      if (remaining === 0) {
+        currentMarker = marker;
+        return true; // break out of detect
+      }
+    });
+
+    return {marker:currentMarker, offset:currentOffset};
+  }
+
+  get text() {
+    return reduce(this.markers, (prev, m) => prev + m.value, '');
+  }
+
+  markersFor(headOffset, tailOffset) {
+    let markers = [];
+    let adjustedHead = 0, adjustedTail = 0;
+    this.markers.forEach(m => {
+      adjustedTail += m.length;
+
+      // if current 'window' of [adjustedHead..adjustedTail] is within
+      // [headOffset..tailOffset] range
+      if (adjustedTail > headOffset && adjustedHead < tailOffset) {
+        let head = Math.max(headOffset - adjustedHead, 0);
+        let tail = m.length - Math.max(adjustedTail - tailOffset, 0);
+        let cloned = m.clone();
+
+        cloned.value = m.value.slice(head, tail);
+        markers.push(cloned);
+      }
+      adjustedHead += m.length;
+    });
+    return markers;
+  }
+
+  // mutates this by appending the other section's (cloned) markers to it
+  join(otherSection) {
+    let beforeMarker = this.markers.tail;
+    let afterMarker = null;
+
+    otherSection.markers.forEach(m => {
+      if (!m.isEmpty) {
+        m = m.clone();
+        this.markers.append(m);
+        if (!afterMarker) {
+          afterMarker = m;
+        }
+      }
+    });
+
+    return { beforeMarker, afterMarker };
+  }
+}

--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -1,8 +1,8 @@
-import Section from './markup-section';
+import Markerable from './_markerable';
 
 export const LIST_ITEM_TYPE = 'list-item';
 
-export default class ListItem extends Section {
+export default class ListItem extends Markerable {
   constructor(tagName, markers=[]) {
     super(tagName, markers);
     this.type = LIST_ITEM_TYPE;
@@ -12,15 +12,16 @@ export default class ListItem extends Section {
     // FIXME need to check if we are going to split into two list items
     // or a list item and a new markup section:
     const isLastItem = !this.next;
-    const createNewSection =
-      (marker.isEmpty && offset === 0) && isLastItem;
+    const createNewSection = (!marker && offset === 0 && isLastItem);
 
     let [beforeSection, afterSection] = [
       this.builder.createListItem(),
-      createNewSection ? this.builder.createMarkupSection('p') : this.builder.createListItem()
+      createNewSection ? this.builder.createMarkupSection() :
+                         this.builder.createListItem()
     ];
 
-    return this._redistributeMarkers(beforeSection, afterSection, marker, offset);
+    return this._redistributeMarkers(
+      beforeSection, afterSection, marker, offset);
   }
 
   splitIntoSections() {

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -1,15 +1,12 @@
-import Section from './markup-section';
+import { normalizeTagName } from '../utils/dom-utils';
 import LinkedList from '../utils/linked-list';
 
 export const LIST_SECTION_TYPE = 'list-section';
 
-export default class ListSection extends Section {
+export default class ListSection {
   constructor(tagName, items=[]) {
-    super(tagName);
+    this.tagName = normalizeTagName(tagName);
     this.type = LIST_SECTION_TYPE;
-
-    // remove the inherited `markers` because they do nothing on a ListSection but confuse
-    this.markers = undefined;
 
     this.items = new LinkedList({
       adoptItem: i => i.section = i.parent = this,

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -94,6 +94,10 @@ const Marker = class Marker extends LinkedItem {
   }
 
   hasMarkup(tagNameOrMarkup) {
+    return !!this.getMarkup(tagNameOrMarkup);
+  }
+
+  getMarkup(tagNameOrMarkup) {
     if (typeof tagNameOrMarkup === 'string') {
       let tagName = normalizeTagName(tagNameOrMarkup);
       return detect(this.markups, markup => markup.tagName === tagName);
@@ -101,10 +105,6 @@ const Marker = class Marker extends LinkedItem {
       let targetMarkup = tagNameOrMarkup;
       return detect(this.markups, markup => markup === targetMarkup);
     }
-  }
-
-  getMarkup(tagName) {
-    return this.hasMarkup(tagName);
   }
 
   join(other) {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -1,31 +1,17 @@
-import {
-  normalizeTagName
-} from '../utils/dom-utils';
+import Markerable from './_markerable';
+import { normalizeTagName } from '../utils/dom-utils';
 
-import {
-  forEach,
-  filter
-} from '../utils/array-utils';
-
-export const DEFAULT_TAG_NAME = normalizeTagName('p');
 export const VALID_MARKUP_SECTION_TAGNAMES = [
   'p', 'h3', 'h2', 'h1', 'blockquote', 'ul', 'ol'
 ].map(normalizeTagName);
+export const DEFAULT_TAG_NAME = VALID_MARKUP_SECTION_TAGNAMES[0];
+
 export const MARKUP_SECTION_TYPE = 'markup-section';
-import LinkedList from "content-kit-editor/utils/linked-list";
-import LinkedItem from "content-kit-editor/utils/linked-item";
 
-export default class Section extends LinkedItem {
-  constructor(tagName, markers=[]) {
-    super();
-    this.markers = new LinkedList({
-      adoptItem: m => m.section = m.parent = this,
-      freeItem: m => m.section = m.parent = null
-    });
-    this.tagName = tagName || DEFAULT_TAG_NAME;
+const MarkupSection = class MarkupSection extends Markerable {
+  constructor(tagName=DEFAULT_TAG_NAME, markers=[]) {
+    super(tagName, markers);
     this.type = MARKUP_SECTION_TYPE;
-
-    markers.forEach(m => this.markers.append(m));
   }
 
   set tagName(val) {
@@ -34,16 +20,6 @@ export default class Section extends LinkedItem {
 
   get tagName() {
     return this._tagName;
-  }
-
-  get isBlank() {
-    if (!this.markers.length) {
-      return true;
-    }
-    let markerWithLength = this.markers.detect((marker) => {
-      return !!marker.length;
-    });
-    return !markerWithLength;
   }
 
   setTagName(newTagName) {
@@ -58,39 +34,6 @@ export default class Section extends LinkedItem {
     this.tagName = DEFAULT_TAG_NAME;
   }
 
-  /**
-   * Splits the marker at the offset, filters empty markers from the result,
-   * and replaces this marker with the new non-empty ones
-   * @param {Marker} marker the marker to split
-   * @return {Array} the new markers that replaced `marker`
-   */
-  splitMarker(marker, offset, endOffset=marker.length) {
-    const newMarkers = filter(marker.split(offset, endOffset), m => !m.isEmpty);
-    this.markers.splice(marker, 1, newMarkers);
-    if (this.markers.length === 0) {
-      let blankMarker = this.builder.createBlankMarker();
-      this.markers.append(blankMarker);
-      newMarkers.push(blankMarker);
-    }
-    return newMarkers;
-  }
-
-  _redistributeMarkers(beforeSection, afterSection, marker, offset=0) {
-    let currentSection = beforeSection;
-    forEach(this.markers, m => {
-      if (m === marker) {
-        const [beforeMarker, ...afterMarkers] = marker.split(offset);
-        beforeSection.markers.append(beforeMarker);
-        forEach(afterMarkers, _m => afterSection.markers.append(_m));
-        currentSection = afterSection;
-      } else {
-        currentSection.markers.append(m.clone());
-      }
-    });
-
-    return [beforeSection, afterSection];
-  }
-
   splitAtMarker(marker, offset=0) {
     let [beforeSection, afterSection] = [
       this.builder.createMarkupSection(this.tagName, []),
@@ -99,63 +42,6 @@ export default class Section extends LinkedItem {
 
     return this._redistributeMarkers(beforeSection, afterSection, marker, offset);
   }
+};
 
-  markerPositionAtOffset(offset) {
-    let currentOffset = 0;
-    let currentMarker;
-    let remaining = offset;
-    this.markers.detect((marker) => {
-      currentOffset = Math.min(remaining, marker.length);
-      remaining -= currentOffset;
-      if (remaining === 0) {
-        currentMarker = marker;
-        return true; // break out of detect
-      }
-    });
-
-    return {marker:currentMarker, offset:currentOffset};
-  }
-
-  // mutates this by appending the other section's (cloned) markers to it
-  join(otherSection) {
-    let beforeMarker = this.markers.tail;
-    let afterMarker = null;
-
-    otherSection.markers.forEach(m => {
-      if (!m.isEmpty) {
-        m = m.clone();
-        this.markers.append(m);
-        if (!afterMarker) {
-          afterMarker = m;
-        }
-      }
-    });
-
-    return { beforeMarker, afterMarker };
-  }
-
-  get text() {
-    let text = '';
-    this.markers.forEach(m => text += m.value);
-    return text;
-  }
-
-  markersFor(headOffset, tailOffset) {
-    let markers = [];
-    let adjustedHead = 0, adjustedTail = 0;
-    this.markers.forEach(m => {
-      adjustedTail += m.length;
-
-      if (adjustedTail > headOffset && adjustedHead < tailOffset) {
-        let head = Math.max(headOffset - adjustedHead, 0);
-        let tail = m.length - Math.max(adjustedTail - tailOffset, 0);
-        let cloned = m.clone();
-
-        cloned.value = m.value.slice(head, tail);
-        markers.push(cloned);
-      }
-      adjustedHead += m.length;
-    });
-    return markers;
-  }
-}
+export default MarkupSection;

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -88,9 +88,6 @@ export default class Section extends LinkedItem {
       }
     });
 
-    beforeSection.coalesceMarkers();
-    afterSection.coalesceMarkers();
-
     return [beforeSection, afterSection];
   }
 
@@ -101,22 +98,6 @@ export default class Section extends LinkedItem {
     ];
 
     return this._redistributeMarkers(beforeSection, afterSection, marker, offset);
-  }
-
-  /**
-   * Remove extranous empty markers, adding one at the end if there
-   * are no longer any markers
-   *
-   * Mutates this section's markers
-   */
-  coalesceMarkers() {
-    forEach(
-      filter(this.markers, m => m.isEmpty),
-      m => this.markers.remove(m)
-    );
-    if (this.markers.isEmpty) {
-      this.markers.append(this.builder.createBlankMarker());
-    }
   }
 
   markerPositionAtOffset(offset) {
@@ -137,9 +118,6 @@ export default class Section extends LinkedItem {
 
   // mutates this by appending the other section's (cloned) markers to it
   join(otherSection) {
-    let wasBlank = this.isBlank;
-    let didAddContent = false;
-
     let beforeMarker = this.markers.tail;
     let afterMarker = null;
 
@@ -150,16 +128,8 @@ export default class Section extends LinkedItem {
         if (!afterMarker) {
           afterMarker = m;
         }
-        didAddContent = true;
       }
     });
-
-    if (wasBlank && didAddContent) {
-      // FIXME: Join should maybe not be on the markup-section
-      beforeMarker.renderNode.scheduleForRemoval();
-      beforeMarker = null;
-    }
-
 
     return { beforeMarker, afterMarker };
   }

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -7,6 +7,7 @@ import Marker from '../models/marker';
 import Markup from '../models/markup';
 import Card from '../models/card';
 import { normalizeTagName } from '../utils/dom-utils';
+import { DEFAULT_TAG_NAME } from '../models/markup-section';
 
 export default class PostNodeBuilder {
   constructor() {
@@ -27,7 +28,7 @@ export default class PostNodeBuilder {
     return this.createPost([ blankMarkupSection ]);
   }
 
-  createMarkupSection(tagName, markers=[], isGenerated=false) {
+  createMarkupSection(tagName=DEFAULT_TAG_NAME, markers=[], isGenerated=false) {
     tagName = normalizeTagName(tagName);
     const section = new MarkupSection(tagName, markers);
     if (isGenerated) {

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -58,13 +58,6 @@ export default class Post {
         currentSection.markers.remove(marker);
       });
 
-      // add a blank marker to any sections that are now empty
-      changedSections.forEach(section => {
-        if (section.markers.isEmpty) {
-          section.markers.append(this.builder.createBlankMarker());
-        }
-      });
-
       if (firstSection !== lastSection) {
         firstSection.join(lastSection);
         removedSections.push(lastSection);

--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -154,10 +154,6 @@ NewHTMLParser.prototype = {
       parseMarkers(section, builder, sectionElement);
       break;
     }
-    if (section.markers.isEmpty) {
-      let marker = this.builder.createBlankMarker();
-      section.markers.append(marker);
-    }
     return section;
   },
   parse: function(postElement) {
@@ -181,8 +177,6 @@ NewHTMLParser.prototype = {
 
     if (post.sections.isEmpty) {
       section = this.builder.createMarkupSection('p');
-      let marker = this.builder.createBlankMarker();
-      section.markers.append(marker);
       post.sections.append(section);
     }
 

--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -4,6 +4,7 @@ import {
   MOBILEDOC_LIST_SECTION_TYPE,
   MOBILEDOC_CARD_SECTION_TYPE
 } from '../renderers/mobiledoc';
+import { filter } from "../utils/array-utils";
 
 /*
  * input mobiledoc: [ markers, elements ]
@@ -27,8 +28,6 @@ export default class MobiledocParser {
 
     if (post.sections.isEmpty) {
       let section = this.builder.createMarkupSection('p');
-      let marker = this.builder.createBlankMarker();
-      section.markers.append(marker);
       post.sections.append(section);
     }
 
@@ -81,10 +80,11 @@ export default class MobiledocParser {
     const section = this.builder.createMarkupSection(tagName);
     post.sections.append(section);
     this.parseMarkers(markers, section);
-    if (section.markers.isEmpty) {
-      let marker = this.builder.createBlankMarker();
-      section.markers.append(marker);
-    }
+    // Strip blank markers after the have been created. This ensures any
+    // markup they include has been correctly populated.
+    filter(section.markers, m => m.isEmpty).forEach(m => {
+      section.markers.remove(m);
+    });
   }
 
   parseListSection([type, tagName, items], post) {

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -107,6 +107,7 @@ export default class PostParser {
 
         renderNode = renderTree.buildRenderNode(marker);
         renderNode.element = textNode;
+        renderNode.renderTree.elements.set(textNode, renderNode);
         renderNode.markClean();
 
         let previousRenderNode = previousMarker && previousMarker.renderNode;

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -38,10 +38,6 @@ export default class SectionParser {
       state.section.markers.append(marker);
     }
 
-    if (section.markers.length === 0) {
-      section.markers.append(this.builder.createBlankMarker());
-    }
-
     return section;
   }
 

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -61,11 +61,20 @@ function compact(enumerable) {
   return filter(enumerable, i => !!i);
 }
 
+function reduce(enumerable, callback, initialValue) {
+  let previousValue = initialValue;
+  forEach(enumerable, (val, index) => {
+    previousValue = callback(previousValue, val, index);
+  });
+  return previousValue;
+}
+
 export {
   detect,
   forEach,
   any,
   filter,
   commonItemLength,
-  compact
+  compact,
+  reduce
 };

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -106,8 +106,11 @@ export default class Cursor {
   // moves cursor to the start of the section
   moveToSection(section, offsetInSection=0) {
     const {marker, offset} = section.markerPositionAtOffset(offsetInSection);
-    if (!marker) { throw new Error('Cannot move cursor to section without a marker'); }
-    this.moveToMarker(marker, offset);
+    if (marker) {
+      this.moveToMarker(marker, offset);
+    } else {
+      this.moveToNode(section.renderNode.element, offsetInSection);
+    }
   }
 
   // moves cursor to marker

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -1,6 +1,7 @@
 import { detect } from 'content-kit-editor/utils/array-utils';
 import { detectParentNode } from 'content-kit-editor/utils/dom-utils';
 import { MARKUP_SECTION_TYPE } from 'content-kit-editor/models/markup-section';
+import { LIST_ITEM_TYPE } from 'content-kit-editor/models/list-item';
 import { MARKER_TYPE } from 'content-kit-editor/models/marker';
 
 function findSectionContaining(sections, childNode) {
@@ -10,6 +11,11 @@ function findSectionContaining(sections, childNode) {
     });
   });
   return section;
+}
+
+function findSectionFromNode(node, renderTree) {
+  const renderNode = renderTree.getElementRenderNode(node);
+  return renderNode && renderNode.postNode;
 }
 
 const Position = class Position {
@@ -48,6 +54,10 @@ const Position = class Position {
           section = renderNode.postNode;
           offsetInSection = offsetInNode;
           break;
+        case LIST_ITEM_TYPE:
+          section = renderNode.postNode;
+          offsetInSection = offsetInNode;
+          break;
         case MARKER_TYPE:
           let marker = renderNode.postNode;
           section = marker.section;
@@ -57,7 +67,8 @@ const Position = class Position {
     }
 
     if (!section) {
-      section = findSectionContaining(sections, node);
+      section = findSectionFromNode(node.parentNode, renderTree) ||
+                findSectionContaining(sections, node);
 
       if (section) {
         offsetInSection = 0;

--- a/src/js/utils/cursor/position.js
+++ b/src/js/utils/cursor/position.js
@@ -1,24 +1,7 @@
 import { detect } from 'content-kit-editor/utils/array-utils';
 import { detectParentNode } from 'content-kit-editor/utils/dom-utils';
-
-// attempts to find a marker by walking up from the childNode
-// and checking to find an element in the renderTree
-// If a marker is found, return the marker's parent.
-// This ensures we get the deepest section when there are nested
-// sections (like ListItem < ListSection)
-// FIXME obviously we would like to do this more declaratively,
-// and not have two ways of finding the current focused section
-function findSectionFromRenderTree(renderTree, childNode) {
-  let currentNode = childNode;
-  while (currentNode) {
-    let renderNode = renderTree.getElementRenderNode(currentNode);
-    if (renderNode) {
-      let marker = renderNode.postNode;
-      return marker.parent;
-    }
-    currentNode = currentNode.parentNode;
-  }
-}
+import { MARKUP_SECTION_TYPE } from 'content-kit-editor/models/markup-section';
+import { MARKER_TYPE } from 'content-kit-editor/models/marker';
 
 function findSectionContaining(sections, childNode) {
   const { result: section } = detectParentNode(childNode, node => {
@@ -54,24 +37,27 @@ const Position = class Position {
   }
 
   static fromNode(renderTree, sections, node, offsetInNode) {
-    // Only markers are registered into the element/renderNode map
-    let markerRenderNode = renderTree.getElementRenderNode(node);
+    // Sections and markers are registered into the element/renderNode map
+    let renderNode = renderTree.getElementRenderNode(node),
+        section = null,
+        offsetInSection = null;
 
-    let section = null, offsetInSection = null;
-    if (markerRenderNode) {
-      let marker = markerRenderNode.postNode;
-      section = marker.section;
-      offsetInSection = marker.offsetInParent(offsetInNode);
+    if (renderNode) {
+      switch (renderNode.postNode.type) {
+        case MARKUP_SECTION_TYPE:
+          section = renderNode.postNode;
+          offsetInSection = offsetInNode;
+          break;
+        case MARKER_TYPE:
+          let marker = renderNode.postNode;
+          section = marker.section;
+          offsetInSection = marker.offsetInParent(offsetInNode);
+          break;
+      }
     }
 
     if (!section) {
-      // The selection should contain two text nodes, but may contain a P
-      // tag if the section only has a blank br marker or on
-      // Chrome/Safari using shift+<Up arrow> can create a selection with
-      // a tag rather than a text node. This fixes that.
-      // See https://github.com/bustlelabs/content-kit-editor/issues/56
-      section = findSectionFromRenderTree(renderTree, node) ||
-        findSectionContaining(sections, node);
+      section = findSectionContaining(sections, node);
 
       if (section) {
         offsetInSection = 0;

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -112,6 +112,17 @@ test('typing enter inserts new section', (assert) => {
   assert.hasElement('#editor p:contains(section)', 'has correct second paragraph text');
 });
 
+test('typing enter inserts new section from blank section', (assert) => {
+  editor = new Editor({mobiledoc: mobileDocWithNoCharacter});
+  editor.render(editorElement);
+  assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
+
+  Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 0);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor p').length, 2, 'has 2 paragraphs after typing return');
+});
+
 test('hitting enter in first section splits it correctly', (assert) => {
   editor = new Editor({mobiledoc: mobileDocWith2Sections});
   editor.render(editorElement);
@@ -486,6 +497,20 @@ test('deleting when after deletion there is a leading space positions cursor at 
     assert.equal($('#editor p:eq(1)').text(), `${text} section`, 'correct text after insertion');
     done();
   });
+});
+
+test('deleting when the previous section is also blank', (assert) => {
+  editor = new Editor({mobiledoc: mobileDocWithNoCharacter});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 0);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.equal($('#editor p').length, 2, 'has 2 paragraphs after typing return');
+
+  Helpers.dom.triggerDelete(editor);
+
+  assert.equal($('#editor p').length, 1, 'has 1 paragraphs after typing delete');
 });
 
 // test: deleting at start of section when previous section is a non-markup section

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -295,4 +295,26 @@ Helpers.skipInPhantom('keystroke of printable character while text is selected d
   });
 });
 
-// test selecting text that includes entire sections deletes the sections
+test('selecting all text across sections and hitting enter deletes and moves cursor to empty section', (assert) => {
+  const done = assert.async();
+  editor = new Editor({mobiledoc: mobileDocWith2Sections});
+  editor.render(editorElement);
+
+  let firstSection = $('#editor p:eq(0)')[0],
+      secondSection = $('#editor p:eq(1)')[0];
+
+  Helpers.dom.selectText('first section', firstSection,
+                         'second section', secondSection);
+
+  Helpers.dom.triggerEnter(editor);
+
+  setTimeout(() => {
+    assert.equal($('#editor p').length, 1, 'single section');
+    assert.equal($('#editor p:eq(0)').text(), '', 'blank text');
+
+    assert.deepEqual(Helpers.dom.getCursorPosition(),
+                    {node: $('#editor p')[0], offset: 0},
+                    'cursor is at start of second section');
+    done();
+  });
+});

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -79,32 +79,6 @@ test('#splitMarker does not remove an existing marker when the offset and endOff
   assert.equal(s.markers.head.value, 'X', 'still correct marker value');
 });
 
-test('#coalesceMarkers removes empty markers', (assert) => {
-  const m1 = builder.createBlankMarker();
-  const m2 = builder.createBlankMarker();
-  const m3 = builder.createMarker('hello');
-  const s = builder.createMarkupSection('p', [m1,m2,m3]);
-
-  assert.equal(s.markers.length, 3, 'precond - correct # markers');
-
-  s.coalesceMarkers();
-  assert.equal(s.markers.length, 1, 'has 1 marker after coalescing');
-  assert.equal(s.markers.head, m3, 'has correct remaining marker');
-});
-
-test('#coalesceMarkers appends a single blank marker if all the markers were blank', (assert) => {
-  const m1 = builder.createBlankMarker();
-  const m2 = builder.createBlankMarker();
-  const s = builder.createMarkupSection('p', [m1,m2]);
-
-  assert.equal(s.markers.length, 2, 'precond - correct # markers');
-
-  s.coalesceMarkers();
-
-  assert.equal(s.markers.length, 1, 'has 1 marker after coalescing');
-  assert.ok(s.markers.head.isEmpty, 'remaining marker is empty');
-});
-
 test('#isBlank returns true if the text length is zero for two markers', (assert) => {
   const m1 = builder.createBlankMarker();
   const m2 = builder.createBlankMarker();

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -28,8 +28,6 @@ test('parse empty content', (assert) => {
   const post = parser.parse(buildDOM(''));
   let section = builder.createMarkupSection('p');
   expectedPost.sections.append(section);
-  let marker = builder.createMarker();
-  section.markers.append(marker);
 
   assert.deepEqual(post, expectedPost);
 });

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -27,8 +27,6 @@ test('#parse empty doc returns an empty post', (assert) => {
   };
 
   let section = builder.createMarkupSection('P');
-  let marker  = builder.createBlankMarker();
-  section.markers.append(marker);
   post.sections.append(section);
   assert.deepEqual(parser.parse(mobiledoc),
                    post);
@@ -43,8 +41,6 @@ test('#parse empty markup section returns an empty post', (assert) => {
   };
 
   let section = builder.createMarkupSection('h2');
-  let marker  = builder.createBlankMarker();
-  section.markers.append(marker);
   post.sections.append(section);
   assert.deepEqual(parser.parse(mobiledoc),
                    post);
@@ -65,6 +61,27 @@ test('#parse doc without marker types', (assert) => {
   let section = builder.createMarkupSection('P', [], false);
   let marker  = builder.createMarker('hello world');
   section.markers.append(marker);
+  post.sections.append(section);
+
+  assert.deepEqual(
+    parsed,
+    post
+  );
+});
+
+test('#parse doc with blank marker', (assert) => {
+  const mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [[
+        1,'P', [[[], 0, '']]
+      ]]
+    ]
+  };
+  const parsed = parser.parse(mobiledoc);
+
+  let section = builder.createMarkupSection('P', [], false);
   post.sections.append(section);
 
   assert.deepEqual(

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -51,7 +51,7 @@ test("renders a dirty post with un-rendered sections", (assert) => {
 
   render(renderTree);
 
-  assert.equal(renderTree.node.element.outerHTML, '<div><p></p><p></p></div>',
+  assert.equal(renderTree.node.element.outerHTML, '<div><p><br></p><p><br></p></div>',
                'correct HTML is rendered');
 
   assert.ok(renderTree.node.childNodes.head,
@@ -126,6 +126,18 @@ test('renders a post with marker', (assert) => {
   node.renderTree = renderTree;
   render(renderTree);
   assert.equal(node.element.innerHTML, '<p><strong>Hi</strong></p>');
+});
+
+test('renders a post with markup empty section', (assert) => {
+  let post = builder.createPost();
+  let section = builder.createMarkupSection('P');
+  post.sections.append(section);
+
+  let node = new RenderNode(post);
+  let renderTree = new RenderTree(node);
+  node.renderTree = renderTree;
+  render(renderTree);
+  assert.equal(node.element.innerHTML, '<p><br></p>');
 });
 
 test('renders a post with multiple markers', (assert) => {


### PR DESCRIPTION
Before this patch, Content-Kit would insert blank markers in any empty section to ensure a cursor could be placed there. This changes that to be a section responsibility. When there are no child markers, a markup section will create a br.

This means throughout the codebase sections and section offset should be used to manage editing actions. There may be no marker at a given cursor position, only using the offset in a section is reliable.

Also ensures correct behavior when deleting two sections in their entirety.