### PR TITLE
Fix link command 98

### DIFF
--- a/src/js/commands/bold.js
+++ b/src/js/commands/bold.js
@@ -1,36 +1,10 @@
 import TextFormatCommand from './text-format';
-import {
-  any
-} from '../utils/array-utils';
-
 export default class BoldCommand extends TextFormatCommand {
   constructor(editor) {
-    super({
+    super(editor, {
+      tag: 'strong',
       name: 'bold',
       button: '<i class="ck-icon-bold"></i>'
     });
-    this.editor = editor;
-    const { builder } = this.editor;
-    this.markup = builder.createMarkup('strong');
-  }
-  exec() {
-    let markerRange = this.editor.cursor.offsets;
-    if (!markerRange.headSection || !markerRange.tailSection) {
-      return;
-    }
-    let markers = this.editor.run((postEditor) => {
-      return postEditor.applyMarkupToMarkers(markerRange, this.markup);
-    });
-    this.editor.selectMarkers(markers);
-  }
-  unexec() {
-    let markerRange = this.editor.cursor.offsets;
-    let markers = this.editor.run((postEditor) => {
-      return postEditor.removeMarkupFromMarkers(markerRange, this.markup);
-    });
-    this.editor.selectMarkers(markers);
-  }
-  isActive() {
-    return any(this.editor.activeMarkers, m => m.hasMarkup(this.markup));
   }
 }

--- a/src/js/commands/format-block.js
+++ b/src/js/commands/format-block.js
@@ -1,21 +1,13 @@
 import TextFormatCommand from './text-format';
-import {
-  any
-} from '../utils/array-utils';
+import { any } from '../utils/array-utils';
 
 class FormatBlockCommand extends TextFormatCommand {
   constructor(editor, options={}) {
-    super(options);
-    this.editor = editor;
+    super(editor, options);
   }
 
   isActive() {
-    const editor = this.editor;
-    const activeSections = editor.activeSections;
-
-    return any(activeSections, section => {
-      return any(this.mappedTags, t => section.tagName === t);
-    });
+    return any(this.editor.activeSections, s => s.tagName === this.tag);
   }
 
   exec() {

--- a/src/js/commands/italic.js
+++ b/src/js/commands/italic.js
@@ -1,36 +1,11 @@
 import TextFormatCommand from './text-format';
-import {
-  any
-} from '../utils/array-utils';
 
 export default class ItalicCommand extends TextFormatCommand {
   constructor(editor) {
-    super({
+    super(editor, {
+      tag: 'em',
       name: 'italic',
       button: '<i class="ck-icon-italic"></i>'
     });
-    this.editor = editor;
-    const { builder } = this.editor;
-    this.markup = builder.createMarkup('em');
-  }
-  exec() {
-    let markerRange = this.editor.cursor.offsets;
-    if (!markerRange.headSection || !markerRange.tailSection) {
-      return;
-    }
-    let markers = this.editor.run((postEditor) => {
-      return postEditor.applyMarkupToMarkers(markerRange, this.markup);
-    });
-    this.editor.selectMarkers(markers);
-  }
-  unexec() {
-    let markerRange = this.editor.cursor.offsets;
-    let markers = this.editor.run((postEditor) => {
-      return postEditor.removeMarkupFromMarkers(markerRange, this.markup);
-    });
-    this.editor.selectMarkers(markers);
-  }
-  isActive() {
-    return any(this.editor.activeMarkers, m => m.hasMarkup(this.markup));
   }
 }

--- a/src/js/commands/link.js
+++ b/src/js/commands/link.js
@@ -1,38 +1,46 @@
 import TextFormatCommand from './text-format';
-import Prompt from '../views/prompt';
-import { getSelectionTagName } from '../utils/selection-utils';
-import { inherit } from 'content-kit-utils';
+import { any }  from 'content-kit-editor/utils/array-utils';
 
-var RegExpHttp = /^https?:\/\//i;
+export default class LinkCommand extends TextFormatCommand {
+  constructor(editor) {
+    super(editor, {
+      name: 'link',
+      tag: 'a',
+      button: '<i class="ck-icon-link"></i>'
+    });
+  }
 
-function LinkCommand() {
-  TextFormatCommand.call(this, {
-    name: 'link',
-    tag: 'a',
-    action: 'createLink',
-    removeAction: 'unlink',
-    button: '<i class="ck-icon-link"></i>',
-    prompt: new Prompt({
-      command: this,
-      placeholder: 'Enter a url, press return...'
-    })
-  });
+  isActive() {
+    return any(this.editor.activeMarkers, m => m.hasMarkup(this.tag));
+  }
+
+  exec(url) {
+    const range = this.editor.cursor.offsets;
+
+    let markers = this.editor.run(postEditor => {
+      const markup = postEditor.builder.createMarkup('a', ['href', url]);
+      return postEditor.applyMarkupToMarkers(range, markup);
+    });
+
+    if (markers.length) {
+      let lastMarker = markers[markers.length - 1];
+      this.editor.cursor.moveToMarker(lastMarker, lastMarker.length);
+    } /* else {
+      // FIXME should handle the case when linking creating no new markers
+      // this.editor.cursor.moveToSection(range.head.section);
+    } */
+  }
+
+  unexec() {
+    const range = this.editor.cursor.offsets;
+
+    const markers = this.editor.run(postEditor => {
+      return postEditor.removeMarkupFromMarkers(
+        range,
+        markup => markup.hasTag('a')
+      );
+    });
+
+    this.editor.selectMarkers(markers);
+  }
 }
-inherit(LinkCommand, TextFormatCommand);
-
-LinkCommand.prototype.exec = function(url) {
-  if (!url) {
-    return LinkCommand._super.prototype.unexec.call(this);
-  }
-
-  if(this.tag === getSelectionTagName()) {
-    this.unexec();
-  } else {
-    if (!RegExpHttp.test(url)) {
-      url = 'http://' + url;
-    }
-    LinkCommand._super.prototype.exec.call(this, url);
-  }
-};
-
-export default LinkCommand;

--- a/src/js/commands/list.js
+++ b/src/js/commands/list.js
@@ -2,8 +2,7 @@ import TextFormatCommand from './text-format';
 
 export default class ListCommand extends TextFormatCommand {
   constructor(editor, options) {
-    super(options);
-    this.editor = editor;
+    super(editor, options);
   }
 
   isActive() {

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -610,10 +610,10 @@ class PostEditor {
    * @return {Array} of markers that are inside the split
    * @public
    */
-  removeMarkupFromMarkers(markerRange, markup) {
+  removeMarkupFromMarkers(markerRange, markupOrMarkupCallback) {
     const markers = this.splitMarkers(markerRange);
     markers.forEach(marker => {
-      marker.removeMarkup(markup);
+      marker.removeMarkup(markupOrMarkupCallback);
       marker.section.renderNode.markDirty();
     });
 

--- a/src/js/models/marker.js
+++ b/src/js/models/marker.js
@@ -5,7 +5,9 @@ import {
 } from '../utils/dom-utils';
 import {
   detect,
-  commonItemLength
+  commonItemLength,
+  forEach,
+  filter
 } from 'content-kit-editor/utils/array-utils';
 import LinkedItem from "content-kit-editor/utils/linked-item";
 
@@ -50,7 +52,22 @@ const Marker = class Marker extends LinkedItem {
     this.markups.push(markup);
   }
 
-  removeMarkup(markup) {
+  removeMarkup(markupOrMarkupCallback) {
+    let callback;
+    if (typeof markupOrMarkupCallback === 'function') {
+      callback = markupOrMarkupCallback;
+    } else {
+      let markup = markupOrMarkupCallback;
+      callback = (_markup) => _markup === markup;
+    }
+
+    forEach(
+      filter(this.markups, callback),
+      m => this._removeMarkup(m)
+    );
+  }
+
+  _removeMarkup(markup) {
     const index = this.markups.indexOf(markup);
     if (index !== -1) {
       this.markups.splice(index, 1);

--- a/src/js/models/markup.js
+++ b/src/js/models/markup.js
@@ -25,6 +25,11 @@ class Markup {
     }
   }
 
+  hasTag(tagName) {
+    tagName = normalizeTagName(tagName);
+    return this.tagName === tagName;
+  }
+
   static isValidElement(element) {
     let tagName = normalizeTagName(element.tagName);
     return VALID_MARKUP_TAGNAMES.indexOf(tagName) !== -1;

--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -1,13 +1,4 @@
-import {
-  containsNode,
-  normalizeTagName
-} from './dom-utils';
-
-var SelectionDirection = {
-  LEFT_TO_RIGHT : 1,
-  RIGHT_TO_LEFT : 2,
-  SAME_NODE     : 3
-};
+import { containsNode } from './dom-utils';
 
 function clearSelection() {
   // FIXME-IE ensure this works on IE 9. It works on IE10.
@@ -36,68 +27,14 @@ function comparePosition(selection) {
   return {headNode, headOffset, tailNode, tailOffset};
 }
 
-function getDirectionOfSelection(selection) {
-  var node = selection.anchorNode;
-  var position = node && node.compareDocumentPosition(selection.focusNode);
-  if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
-    return SelectionDirection.LEFT_TO_RIGHT;
-  } else if (position & Node.DOCUMENT_POSITION_PRECEDING) {
-    return SelectionDirection.RIGHT_TO_LEFT;
-  }
-  return SelectionDirection.SAME_NODE;
-}
-
-function getSelectionElement(selection) {
-  selection = selection || window.getSelection();
-  // FIXME it used to return `anchorNode` when selection direction is `LEFT_TO_RIGHT`,
-  // but I think that was a bug. In Safari and Chrome the selection usually had the
-  // same anchorNode and focusNode when selecting text, so it didn't matter.
-  var node = getDirectionOfSelection(selection) === SelectionDirection.LEFT_TO_RIGHT ? selection.focusNode : selection.anchorNode;
-  return node && (node.nodeType === 3 ? node.parentNode : node);
-}
-
-function getSelectionTagName() {
-  var element = getSelectionElement();
-  return element ? normalizeTagName(element.tagName) : null;
-}
-
-function tagsInSelection(selection) {
-  var element = getSelectionElement(selection);
-  var tags = [];
-  while(element) {
-    if (element.contentEditable === 'true') { break; } // Stop traversing up dom when hitting an editor element
-    if (element.tagName) {
-      tags.push(normalizeTagName(element.tagName));
-    }
-    element = element.parentNode;
-  }
-  return tags;
-}
-
 function restoreRange(range) {
   clearSelection();
   var selection = window.getSelection();
   selection.addRange(range);
 }
 
-function selectNode(node) {
-  clearSelection();
-
-  var range = document.createRange();
-  range.setStart(node, 0);
-  range.setEnd(node, node.length);
-
-  var selection = window.getSelection();
-  selection.addRange(range);
-}
-
 export {
-  getDirectionOfSelection,
-  getSelectionElement,
-  getSelectionTagName,
-  tagsInSelection,
   restoreRange,
-  selectNode,
   containsNode,
   clearSelection,
   comparePosition

--- a/src/js/views/embed-intent.js
+++ b/src/js/views/embed-intent.js
@@ -1,8 +1,6 @@
 import View from './view';
 import Toolbar from './toolbar';
-import { inherit } from 'content-kit-utils';
 import { positionElementToLeftOf, positionElementCenteredIn } from '../utils/element-utils';
-import { createDiv } from '../utils/element-utils';
 import Keycodes from '../utils/keycodes';
 
 var LayoutStyle = {
@@ -17,120 +15,113 @@ function computeLayoutStyle(rootElement) {
   return LayoutStyle.CENTERED;
 }
 
-function EmbedIntent(options) {
-  var embedIntent = this;
-  var rootElement = embedIntent.rootElement = options.rootElement;
-  options.classNames = ['ck-embed-intent'];
-  View.call(embedIntent, options);
+class EmbedIntent extends View {
+  constructor(options={}) {
+    options.classNames = ['ck-embed-intent'];
+    super(options);
+    const rootElement = this.rootElement = options.rootElement;
 
-  embedIntent.isActive = false;
-  embedIntent.editorContext = options.editorContext;
-  embedIntent.loadingIndicator = createDiv('ck-embed-loading');
-  embedIntent.button = document.createElement('button');
-  embedIntent.button.className = 'ck-embed-intent-btn';
-  embedIntent.button.title = 'Insert image or embed...';
-  embedIntent.element.appendChild(embedIntent.button);
-
-  this.addEventListener(embedIntent.button, 'click', (e) => {
-    if (embedIntent.isActive) {
-      embedIntent.deactivate();
-    } else {
-      embedIntent.activate();
-    }
-    e.stopPropagation();
-  });
-
-  embedIntent.toolbar = new Toolbar({
-    container: embedIntent.element,
-    embedIntent: embedIntent,
-    editor: embedIntent.editorContext,
-    commands: options.commands,
-    direction: Toolbar.Direction.RIGHT
-  });
-
-  const embedIntentHandler = () => {
-    const {editorContext:editor} = this;
-    if (this._isDestroyed || editor._isDestroyed) {
-      return;
-    }
-
-    const {headSection, isCollapsed} = embedIntent.editorContext.cursor.offsets;
-    const headRenderNode = headSection && headSection.renderNode && headSection.renderNode.element;
-
-    if (headRenderNode && headSection.isBlank && isCollapsed) {
-      embedIntent.showAt(headRenderNode);
-    } else {
-      embedIntent.hide();
-    }
-  };
-
-  this.addEventListener(rootElement, 'keyup', embedIntentHandler);
-  this.addEventListener(document, 'click', () => {
-    setTimeout(() => {
-      embedIntentHandler();
-    });
-  });
-
-  this.addEventListener(document, 'keyup', (e) => {
-    if (e.keyCode === Keycodes.ESC) {
-      embedIntent.hide();
-    }
-  });
-
-  this.addEventListener(window, 'resize', () => {
-    if(embedIntent.isShowing) {
-      embedIntent.reposition();
-    }
-  });
-}
-inherit(EmbedIntent, View);
-
-EmbedIntent.prototype.hide = function() {
-  if (EmbedIntent._super.prototype.hide.call(this)) {
-    this.deactivate();
-  }
-};
-
-EmbedIntent.prototype.showAt = function(node) {
-  this.atNode = node;
-  this.show();
-  this.deactivate();
-  this.reposition();
-};
-
-EmbedIntent.prototype.reposition = function() {
-  if (computeLayoutStyle(this.rootElement) === LayoutStyle.GUTTER) {
-    positionElementToLeftOf(this.element, this.atNode);
-  } else {
-    positionElementCenteredIn(this.element, this.atNode);
-  }
-};
-
-EmbedIntent.prototype.activate = function() {
-  if (!this.isActive) {
-    this.addClass('activated');
-    this.toolbar.show();
-    this.isActive = true;
-  }
-};
-
-EmbedIntent.prototype.deactivate = function() {
-  if (this.isActive) {
-    this.removeClass('activated');
-    this.toolbar.hide();
     this.isActive = false;
+    this.editorContext = options.editorContext;
+    this.button = document.createElement('button');
+    this.button.className = 'ck-embed-intent-btn';
+    this.button.title = 'Insert image or embed...';
+    this.element.appendChild(this.button);
+
+    this.addEventListener(this.button, 'click', (e) => {
+      if (this.isActive) {
+        this.deactivate();
+      } else {
+        this.activate();
+      }
+      e.stopPropagation();
+    });
+
+    this.toolbar = new Toolbar({
+      container: this.element,
+      embedIntent: this,
+      editor: this.editorContext,
+      commands: options.commands,
+      direction: Toolbar.Direction.RIGHT
+    });
+
+    const embedIntentHandler = () => {
+      const {editorContext:editor} = this;
+      if (this._isDestroyed || editor._isDestroyed) {
+        return;
+      }
+
+      const {headSection, isCollapsed} = this.editorContext.cursor.offsets;
+      const headRenderNode = headSection && headSection.renderNode && headSection.renderNode.element;
+
+      if (headRenderNode && headSection.isBlank && isCollapsed) {
+        this.showAt(headRenderNode);
+      } else {
+        this.hide();
+      }
+    };
+
+    this.addEventListener(rootElement, 'keyup', embedIntentHandler);
+    this.addEventListener(document, 'click', () => {
+      setTimeout(() => {
+        embedIntentHandler();
+      });
+    });
+
+    this.addEventListener(document, 'keyup', (e) => {
+      if (e.keyCode === Keycodes.ESC) {
+        this.hide();
+      }
+    });
+
+    this.addEventListener(window, 'resize', () => {
+      if(this.isShowing) {
+        this.reposition();
+      }
+    });
   }
-};
 
-EmbedIntent.prototype.showLoading = function() {
-  var embedIntent = this;
-  var loadingIndicator = embedIntent.loadingIndicator;
-  embedIntent.hide();
-  embedIntent.atNode.appendChild(loadingIndicator);
-};
+  hide() {
+    if (super.hide()) {
+      this.deactivate();
+    }
+  }
 
-EmbedIntent.prototype.hideLoading = function() {
-  this.atNode.removeChild(this.loadingIndicator);
-};
+  showAt(node) {
+    this.atNode = node;
+    this.show();
+    this.deactivate();
+    this.reposition();
+  }
+
+  reposition() {
+    if (computeLayoutStyle(this.rootElement) === LayoutStyle.GUTTER) {
+      positionElementToLeftOf(this.element, this.atNode);
+    } else {
+      positionElementCenteredIn(this.element, this.atNode);
+    }
+  }
+
+  activate() {
+    if (!this.isActive) {
+      this.addClass('activated');
+      this.toolbar.show();
+      this.isActive = true;
+    }
+  }
+
+  deactivate() {
+    if (this.isActive) {
+      this.removeClass('activated');
+      this.toolbar.hide();
+      this.isActive = false;
+    }
+  }
+
+  destroy() {
+    this.toolbar.destroy();
+    super.destroy();
+  }
+}
 
 export default EmbedIntent;

--- a/src/js/views/prompt.js
+++ b/src/js/views/prompt.js
@@ -18,35 +18,42 @@ class Prompt extends View {
   constructor(options) {
     options.tagName = 'input';
     super(options);
+    this.toolbar = options.toolbar;
 
-    var prompt = this;
-
-    prompt.command = options.command;
-    prompt.element.placeholder = options.placeholder || '';
-    this.addEventListener(prompt.element, 'click', (e) => {
+    this.element.placeholder = options.placeholder || '';
+    this.addEventListener(this.element, 'click', (e) => {
       // prevents closing prompt when clicking input
       e.stopPropagation();
     });
-    this.addEventListener(prompt.element, 'keyup', (e) => {
-      const entry = prompt.element.value;
+    this.addEventListener(this.element, 'keyup', (e) => {
+      const entry = this.element.value;
 
-      if (entry && prompt.range && !e.shiftKey && e.which === Keycodes.ENTER) {
-        restoreRange(prompt.range);
-        this.command.exec(entry);
-        if (this.onComplete) { this.onComplete(); }
+      if (entry && this.range && !e.shiftKey && e.which === Keycodes.ENTER) {
+        restoreRange(this.range);
+        this.doComplete(entry);
       }
     });
 
     this.addEventListener(window, 'resize', () => {
       var activeHilite = hiliter.parentNode;
-      var range = prompt.range;
+      var range = this.range;
       if(activeHilite && range) {
         positionHiliteRange(range);
       }
     });
   }
 
-  show(callback) {
+  doComplete(value) {
+    this.hide();
+    this.onComplete(value);
+    this.toolbar.hide();
+  }
+
+  show(callback=() => {}) {
+    const { toolbar } = this;
+    toolbar.displayPrompt(this);
+
+    this.onComplete = callback;
     var element = this.element;
     var selection = window.getSelection();
     var range = selection && selection.rangeCount && selection.getRangeAt(0);
@@ -60,9 +67,6 @@ class Prompt extends View {
         // defer focus (disrupts mouseup events)
         element.focus();
       });
-      if (callback) {
-        this.onComplete = callback;
-      }
     }
   }
 
@@ -70,6 +74,7 @@ class Prompt extends View {
     if (hiliter.parentNode) {
       container.removeChild(hiliter);
     }
+    this.toolbar.dismissPrompt();
   }
 }
 

--- a/src/js/views/reversible-prompt-button.js
+++ b/src/js/views/reversible-prompt-button.js
@@ -1,0 +1,23 @@
+import ReversibleToolbarButton from './reversible-toolbar-button';
+
+export default class PromptButton extends ReversibleToolbarButton {
+  constructor(command, editor) {
+    super(command, editor);
+  }
+
+  get prompt() {
+    return this.toolbar.prompt;
+  }
+
+  handleClick(e) {
+    e.stopPropagation();
+
+    const { prompt } = this;
+
+    if (!this.active) {
+      prompt.show((...args) => this.exec(...args));
+    } else {
+      this.unexec();
+    }
+  }
+}

--- a/src/js/views/reversible-toolbar-button.js
+++ b/src/js/views/reversible-toolbar-button.js
@@ -25,10 +25,18 @@ class ReversibleToolbarButton {
     e.stopPropagation();
 
     if (this.active) {
-      this.command.unexec();
+      this.unexec();
     } else {
-      this.command.exec();
+      this.exec();
     }
+  }
+
+  exec(...args) {
+    this.command.exec(...args);
+  }
+
+  unexec(...args) {
+    this.command.unexec(...args);
   }
 
   updateActiveState() {
@@ -54,6 +62,10 @@ class ReversibleToolbarButton {
 
   get active() {
     return this._active;
+  }
+
+  destroy() {
+    this.removeAllEventListeners();
   }
 }
 

--- a/src/js/views/text-format-toolbar.js
+++ b/src/js/views/text-format-toolbar.js
@@ -12,8 +12,8 @@ export default class TextFormatToolbar extends Toolbar {
   }
 
   handleResize() {
-    if(this.isShowing) {
-      let activePromptRange = this.activePrompt && this.activePrompt.range;
+    if (this.isShowing) {
+      const activePromptRange = this.activePrompt && this.activePrompt.range;
       this.positionToContent(activePromptRange ? activePromptRange : window.getSelection().getRangeAt(0));
     }
   }

--- a/src/js/views/toolbar-button.js
+++ b/src/js/views/toolbar-button.js
@@ -1,51 +1,37 @@
-var buttonClassName = 'ck-toolbar-btn';
 import mixin from '../utils/mixin';
 import EventListenerMixin from '../utils/event-listener';
 
-function ToolbarButton(options) {
-  var button = this;
-  var toolbar = options.toolbar;
-  var command = options.command;
-  var prompt = command.prompt;
-  var element = document.createElement('button');
+const ELEMENT_TYPE = 'button';
+const BUTTON_CLASS_NAME = 'ck-toolbar-btn';
 
-  button.element = element;
-  button.command = command;
-  button.isActive = false;
+class ToolbarButton {
+  constructor(options={}) {
+    const { toolbar, command } = options;
+    this.command = command;
+    this.element = this.createElement();
+    this.isActive = false;
 
-  element.title = command.name;
-  element.className = buttonClassName;
-  element.innerHTML = command.button;
-  this.addEventListener(element, 'click', (e) => {
-    if (!button.isActive && prompt) {
-      toolbar.displayPrompt(prompt);
-    } else {
+    this.addEventListener(this.element, 'click', (e) => {
       command.exec();
-      toolbar.updateForSelection();
       if (toolbar.embedIntent) {
         toolbar.embedIntent.hide();
       }
-    }
-    e.stopPropagation();
-  });
-}
-
-ToolbarButton.prototype = {
-  setActive: function() {
-    var button = this;
-    if (!button.isActive) {
-      button.element.className = buttonClassName + ' active';
-      button.isActive = true;
-    }
-  },
-  setInactive: function() {
-    var button = this;
-    if (button.isActive) {
-      button.element.className = buttonClassName;
-      button.isActive = false;
-    }
+      e.stopPropagation();
+    });
   }
-};
+
+  createElement() {
+    const element = document.createElement(ELEMENT_TYPE);
+    element.className = BUTTON_CLASS_NAME;
+    element.innerHTML = this.command.button;
+    element.title = this.command.name;
+    return element;
+  }
+
+  destroy() {
+    this.removeAllEventListeners();
+  }
+}
 
 mixin(ToolbarButton, EventListenerMixin);
 

--- a/src/js/views/view.js
+++ b/src/js/views/view.js
@@ -30,10 +30,9 @@ class View {
   }
 
   hide() {
-    var view = this;
-    if(view.isShowing) {
-      view.container.removeChild(view.element);
-      view.isShowing = false;
+    if (this.isShowing) {
+      this.container.removeChild(this.element);
+      this.isShowing = false;
       return true;
     }
   }

--- a/tests/helpers/assertions.js
+++ b/tests/helpers/assertions.js
@@ -1,6 +1,8 @@
 /* global QUnit, $ */
 
 import DOMHelper from './dom';
+import ToolbarHelper from './toolbar';
+const { _getToolbarButton } = ToolbarHelper;
 
 export default function registerAssertions() {
   QUnit.assert.hasElement = function(selector, message=`hasElement "${selector}"`) {
@@ -21,5 +23,23 @@ export default function registerAssertions() {
               selected,
               text,
               message);
+  };
+
+  QUnit.assert.toolbarVisible = function(message=`toolbar is visible`) {
+    QUnit.assert.hasElement('.ck-toolbar', message);
+  };
+
+  QUnit.assert.toolbarHidden = function(message=`toolbar is not visible`) {
+    QUnit.assert.hasNoElement('.ck-toolbar', message);
+  };
+
+  QUnit.assert.inactiveButton = function(name, message=`button ${name} is inactive`) {
+    const btn = _getToolbarButton(name);
+    QUnit.assert.ok(!btn.is('.active'), message);
+  };
+
+  QUnit.assert.activeButton = function(name, message=`button ${name} is active`) {
+    const btn = _getToolbarButton(name);
+    QUnit.assert.ok(btn.is('.active'), message);
   };
 }

--- a/tests/helpers/toolbar.js
+++ b/tests/helpers/toolbar.js
@@ -1,7 +1,12 @@
 import { triggerEvent } from './dom';
 
+function _getToolbarButton(name) {
+  const btnSelector = `.ck-toolbar-btn[title="${name}"]`;
+  return $(btnSelector);
+}
+
 function getToolbarButton(assert, name) {
-  let btnSelector = `.ck-toolbar-btn[title="${name}"]`;
+  const btnSelector = `.ck-toolbar-btn[title="${name}"]`;
   return assert.hasElement(btnSelector);
 }
 
@@ -30,6 +35,7 @@ function assertInactiveButton(assert, buttonTitle) {
 
 const ToolbarHelpers = {
   getToolbarButton,
+  _getToolbarButton,
   assertVisible,
   assertHidden,
   assertActiveButton,


### PR DESCRIPTION
fixes #98 

Changes the link command to use `postEditor`. This PR:

  * removes the last usages of `document.execCommand`
  * removes a lot of now-unnecessary selection-related methods in "selection-utils"
  * refactors several of the views to catch some memory leak and to use a more consistent class hierarchy