### PR TITLE
Select across cards

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -442,7 +442,10 @@ var sampleMobiledocs = {
         [1, "H2", [
           [[], 0, "Input Card"]
         ]],
-        [10, "input-card"]
+        [10, "input-card"],
+        [1, "P", [
+          [[], 0, "Text after the card."]
+        ]]
       ]
     ]
   },

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -329,27 +329,19 @@ class Editor {
   }
 
   handleNewline(event) {
-    let offsets = this.cursor.offsets;
+    if (!this.cursor.hasCursor()) { return ;}
 
-    // if there's no left/right nodes, we are probably not in the editor,
-    // or we have selected some non-marker thing like a card
-    if (!offsets.headSection || !offsets.tailSection) {
-      return;
-    }
-
+    const range = this.cursor.offsets;
     event.preventDefault();
 
-    let cursorSection;
-    this.run((postEditor) => {
-      if (this.cursor.hasSelection()) {
-        postEditor.deleteRange(offsets);
-        if (offsets.headSection.isBlank) {
-          cursorSection = offsets.headSection;
-          return;
+    const cursorSection = this.run((postEditor) => {
+      if (!range.isCollapsed) {
+        postEditor.deleteRange(range);
+        if (range.head.section.isBlank) {
+          return range.head.section;
         }
       }
-      const headPosition = offsets.head;
-      cursorSection = postEditor.splitSection(headPosition)[1];
+      return postEditor.splitSection(range.head)[1];
     });
     this.cursor.moveToSection(cursorSection);
   }


### PR DESCRIPTION
Properly `deleteRange` when the range includes non-markerable and non-container-y (like a ListSection, which contains child ListItems) sections. This ensure that selecting text that includes a card section will remove that card section when deleting or typing over the selection.

fixes #108 