### PR TITLE
Implement text expansions

### DIFF
--- a/src/js/editor/text-expansions.js
+++ b/src/js/editor/text-expansions.js
@@ -1,0 +1,92 @@
+import Keycodes from '../utils/keycodes';
+import Key from '../utils/key';
+import { detect } from '../utils/array-utils';
+import { MARKUP_SECTION_TYPE } from '../models/markup-section';
+
+const { SPACE } = Keycodes;
+
+function replaceWithListSection(editor, listTagName) {
+  const {head: {section}} = editor.cursor.offsets;
+
+  const newSection = editor.run(postEditor => {
+    const {builder} = postEditor;
+    const listItem = builder.createListItem();
+    const listSection = builder.createListSection(listTagName, [listItem]);
+
+    postEditor.replaceSection(section, listSection);
+    return listItem;
+  });
+
+  editor.cursor.moveToSection(newSection);
+}
+
+function replaceWithHeaderSection(editor, headingTagName) {
+  const {head: {section}} = editor.cursor.offsets;
+
+  const newSection = editor.run(postEditor => {
+    const {builder} = postEditor;
+    const newSection = builder.createMarkupSection(headingTagName);
+    postEditor.replaceSection(section, newSection);
+    return newSection;
+  });
+
+  editor.cursor.moveToSection(newSection);
+}
+
+export function validateExpansion(expansion) {
+  return !!expansion.trigger && !!expansion.text && !!expansion.run;
+}
+
+export const DEFAULT_TEXT_EXPANSIONS = [
+  {
+    trigger: SPACE,
+    text: '*',
+    run: (editor) => {
+      replaceWithListSection(editor, 'ul');
+    }
+  },
+  {
+    trigger: SPACE,
+    text: '1',
+    run: (editor) => {
+      replaceWithListSection(editor, 'ol');
+    }
+  },
+  {
+    trigger: SPACE,
+    text: '1.',
+    run: (editor) => {
+      replaceWithListSection(editor, 'ol');
+    }
+  },
+  {
+    trigger: SPACE,
+    text: '##',
+    run: (editor) => {
+      replaceWithHeaderSection(editor, 'h2');
+    }
+  },
+  {
+    trigger: SPACE,
+    text: '###',
+    run: (editor) => {
+      replaceWithHeaderSection(editor, 'h3');
+    }
+  }
+];
+
+export function findExpansion(expansions, keyEvent, editor) {
+  const key = Key.fromEvent(keyEvent);
+  if (!key.isPrintable()) { return; }
+
+  const {head:{section, offset}} = editor.cursor.offsets;
+  if (section.type !== MARKUP_SECTION_TYPE) { return; }
+
+  // FIXME this is potentially expensive to calculate and might be better
+  // perf to first find expansions matching the trigger and only if matches
+  // are found then calculating the _text
+  const _text = section.textUntil(offset);
+  return detect(
+    expansions,
+    ({trigger, text}) => key.keyCode === trigger && _text === text);
+}

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -116,6 +116,10 @@ export default class Markerable extends LinkedItem {
     return {marker:currentMarker, offset:currentOffset};
   }
 
+  textUntil(offset) {
+    return this.text.slice(0, offset);
+  }
+
   get text() {
     return reduce(this.markers, (prev, m) => prev + m.value, '');
   }

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -12,7 +12,7 @@ import { startsWith, endsWith } from '../utils/string-utils';
 import { addClassName } from '../utils/dom-utils';
 
 export const NO_BREAK_SPACE = '\u00A0';
-const SPACE = ' ';
+export const SPACE = ' ';
 
 function createElementFromMarkup(doc, markup) {
   var element = doc.createElement(markup.tagName);

--- a/src/js/utils/event-listener.js
+++ b/src/js/utils/event-listener.js
@@ -1,3 +1,5 @@
+import { filter } from './array-utils';
+
 export default class EventListenerMixin {
   addEventListener(context, eventName, listener) {
     if (!this._eventListeners) { this._eventListeners = []; }
@@ -9,6 +11,20 @@ export default class EventListenerMixin {
     const listeners = this._eventListeners || [];
     listeners.forEach(([context, ...args]) => {
       context.removeEventListener(...args);
+    });
+  }
+
+  // This is primarily useful for programmatically simulating events on the
+  // editor from the tests.
+  triggerEvent(context, eventName, event) {
+    let matches = filter(
+      this._eventListeners,
+      ([_context, _eventName]) => {
+        return context === _context && eventName === _eventName;
+      }
+    );
+    matches.forEach(([context, eventName, listener]) => {
+      listener.call(context, event);
     });
   }
 }

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -72,7 +72,7 @@ test('highlight text, click "bold", type more text, re-select text, bold button 
     assert.equal(textNode.textContent, 'IS A', 'precond - correct node');
 
     Helpers.dom.moveCursorTo(textNode, 'IS'.length);
-    Helpers.dom.insertText('X');
+    Helpers.dom.insertText(editor, 'X');
 
     assert.hasElement('strong:contains(ISX A)', 'adds text to bold');
 
@@ -233,14 +233,14 @@ Helpers.skipInPhantom('highlight text, click "link" button shows input for URL, 
     setTimeout(() => {
       assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
 
-      Helpers.dom.insertText('X');
+      Helpers.dom.insertText(editor, 'X');
 
       assert.hasElement(`#editor p:contains(${selectedText}X)`,
                         'inserts text after selected text');
       assert.hasNoElement(`#editor a:contains(${selectedText}X)`,
                         'inserted text does not extend "a" tag');
 
-      Helpers.dom.insertText('X');
+      Helpers.dom.insertText(editor, 'X');
       assert.hasElement(`#editor p:contains(${selectedText}XX)`,
                         'inserts text after selected text again');
 

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -37,7 +37,7 @@ test('can type in middle of a list item', (assert) => {
   assert.ok(!!listItem, 'precond - has li');
 
   Helpers.dom.moveCursorTo(listItem.childNodes[0], 'first'.length);
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor li:contains(firstX item)', 'inserts text at right spot');
 });
@@ -49,7 +49,7 @@ test('can type at end of a list item', (assert) => {
   assert.ok(!!listItem, 'precond - has li');
 
   Helpers.dom.moveCursorTo(listItem.childNodes[0], 'first item'.length);
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor li:contains(first itemX)', 'inserts text at right spot');
 });
@@ -61,7 +61,7 @@ test('can type at start of a list item', (assert) => {
   assert.ok(!!listItem, 'precond - has li');
 
   Helpers.dom.moveCursorTo(listItem.childNodes[0], 0);
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor li:contains(Xfirst item)', 'inserts text at right spot');
 });
@@ -95,8 +95,8 @@ test('can exit list section altogether by deleting', (assert) => {
   assert.hasNoElement('#editor li:contains(second item)', 'second li is gone');
   assert.hasElement('#editor p:contains(second item)', 'second li becomes p');
 
-  Helpers.dom.insertText('X');
-  
+  Helpers.dom.insertText(editor, 'X');
+
   assert.hasElement('#editor p:contains(Xsecond item)', 'new text is in right spot');
 });
 
@@ -142,7 +142,7 @@ test('can hit enter at end of list item to add new item', (assert) => {
   let newLi = $('#editor li:eq(1)');
   assert.equal(newLi.text(), '', 'new li has no text');
 
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
   assert.hasElement('#editor li:contains(X)', 'text goes in right spot');
 
   const liCount = $('#editor li').length;
@@ -179,7 +179,7 @@ test('hitting enter to add list item, deleting to remove it, adding new list ite
   assert.equal($('#editor li').length, 2, 'removes newly added li after enter on last list item');
   assert.equal($('#editor p').length, 2, 'adds a second p section');
 
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor p:eq(0):contains(X)', 'inserts text in right spot');
 });
@@ -203,6 +203,6 @@ test('hitting enter at empty last list item exists list', (assert) => {
   assert.equal($('#editor p').length, 1, 'adds 1 new p');
   assert.equal($('#editor p').text(), '', 'p has no text');
 
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
   assert.hasElement('#editor p:contains(X)', 'text goes in right spot');
 });

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -173,7 +173,7 @@ test('hitting enter at end of a section creates new empty section', (assert) => 
   assert.hasElement('#editor p:eq(0):contains(only section)', 'has same first section text');
   assert.hasElement('#editor p:eq(1):contains()', 'second section has no text');
 
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor p:eq(1):contains(X)', 'text is inserted in the new section');
 });
@@ -191,7 +191,7 @@ test('hitting enter in a section creates a new basic section', (assert) => {
 
   Helpers.dom.moveCursorTo($('#editor h2')[0].childNodes[0], 'abc'.length);
   Helpers.dom.triggerEnter(editor);
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor h2:contains(abc)', 'h2 still there');
   assert.hasElement('#editor p:contains(X)', 'p tag instead of h2 generated');
@@ -308,7 +308,7 @@ test('keystroke of delete when cursor is after only char in only marker of secti
 
   assert.hasElement('#editor p:eq(0):contains()', 'first p is empty');
 
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
   assert.hasElement('#editor p:eq(0):contains(X)', 'text is added back to section');
 });
 
@@ -324,7 +324,7 @@ test('keystroke of character in empty section adds character, moves cursor', (as
   Helpers.dom.moveCursorTo(textNode, 0);
 
   const letter = 'M';
-  Helpers.dom.insertText(letter);
+  Helpers.dom.insertText(editor, letter);
 
   assert.equal(getTextNode().textContent, letter, 'adds character');
   assert.equal(getTextNode().textContent.length, 1);
@@ -334,7 +334,7 @@ test('keystroke of character in empty section adds character, moves cursor', (as
                   `cursor moves to end of ${letter} text node`);
 
   const otherLetter = 'X';
-  Helpers.dom.insertText(otherLetter);
+  Helpers.dom.insertText(editor, otherLetter);
 
   assert.equal(getTextNode().textContent, `${letter}${otherLetter}`,
                'adds character in the correct spot');
@@ -490,7 +490,7 @@ test('deleting when after deletion there is a trailing space positions cursor at
   assert.equal($('#editor p:eq(0)').text(), `first${NO_BREAK_SPACE}`, 'precond - correct text after deleting last char before space');
 
   let text = 'e';
-  Helpers.dom.insertText(text);
+  Helpers.dom.insertText(editor, text);
 
   setTimeout(() => {
     assert.equal($('#editor p:eq(0)').text(), `first ${text}`, 'character is placed after space');
@@ -510,7 +510,7 @@ test('deleting when after deletion there is a leading space positions cursor at 
 
   assert.equal($('#editor p:eq(1)').text(), `${NO_BREAK_SPACE}section`, 'correct text after deletion');
   let text = 'e';
-  Helpers.dom.insertText(text);
+  Helpers.dom.insertText(editor, text);
 
   setTimeout(() => {
     assert.equal($('#editor p:eq(1)').text(), `${text} section`, 'correct text after insertion');

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -67,7 +67,7 @@ test('selecting an entire section and deleting removes it', (assert) => {
   assert.hasNoElement('p:contains(second section)', 'deletes contents of second section');
   assert.equal($('#editor p').length, 2, 'still has 2 sections');
 
-  Helpers.dom.insertText('X');
+  Helpers.dom.insertText(editor, 'X');
 
   assert.hasElement('#editor p:eq(1):contains(X)', 'inserts text in correct spot');
 

--- a/tests/acceptance/editor-text-expansions-test.js
+++ b/tests/acceptance/editor-text-expansions-test.js
@@ -1,0 +1,145 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+
+const { module, test } = Helpers;
+
+let editor, editorElement;
+
+function insertText(text, cursorNode) {
+  if (!cursorNode) {
+    cursorNode = $('#editor p:eq(0)')[0].firstChild;
+  }
+  Helpers.dom.moveCursorTo(cursorNode);
+  Helpers.dom.insertText(editor, text);
+}
+
+module('Acceptance: Editor: Text Expansions', {
+  beforeEach() {
+    editorElement = document.createElement('div');
+    editorElement.setAttribute('id', 'editor');
+    $('#qunit-fixture').append(editorElement);
+  },
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('typing "## " converts to h2', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  insertText('## ');
+
+  assert.hasNoElement('#editor p', 'p is gone');
+  assert.hasElement('#editor h2', 'p -> h2');
+
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasElement('#editor h2:contains(X)', 'text is inserted correctly');
+});
+
+test('space is required to trigger "## " expansion', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  insertText('##X');
+
+  assert.hasElement('#editor p:contains(##X)', 'text inserted, no expansion');
+});
+
+test('typing "### " converts to h3', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  insertText('### ');
+
+  assert.hasNoElement('#editor p', 'p is gone');
+  assert.hasElement('#editor h3', 'p -> h3');
+
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasElement('#editor h3:contains(X)', 'text is inserted correctly');
+});
+
+test('typing "* " converts to ul > li', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  insertText('* ');
+
+  assert.hasNoElement('#editor p', 'p is gone');
+  assert.hasElement('#editor ul > li', 'p -> "ul > li"');
+
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+});
+
+test('typing "* " inside of a list section does not create a new list section', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, listSection, listItem}) => post([listSection('ul', [listItem()])]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  assert.hasElement('#editor ul > li', 'precond - has li');
+
+  const cursorNode = $('#editor li:eq(0)')[0].firstChild;
+  insertText('* ', cursorNode);
+
+  // note: the actual text is "*&nbsp;", so only check that the "*" is there,
+  // because checking for "* " will fail
+  assert.hasElement('#editor ul > li:contains(*)', 'adds text without expanding it');
+});
+
+test('typing "1 " converts to ol > li', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  insertText('1 ');
+
+  assert.hasNoElement('#editor p', 'p is gone');
+  assert.hasElement('#editor ol > li', 'p -> "ol > li"');
+
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+});
+
+test('typing "1. " converts to ol > li', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+  insertText('1. ');
+
+  assert.hasNoElement('#editor p', 'p is gone');
+  assert.hasElement('#editor ol > li', 'p -> "ol > li"');
+
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasElement('#editor li:contains(X)', 'text is inserted correctly');
+});
+
+test('a new expansion can be registered', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection}) => post([markupSection()]));
+
+  let didExpand = false;
+  editor = new Editor({mobiledoc});
+  editor.registerExpansion({
+    trigger: ' '.charCodeAt(0),
+    text: 'quote',
+    run: () => didExpand = true
+  });
+  editor.render(editorElement);
+  insertText('quote ');
+
+  assert.ok(didExpand, 'expansion was run');
+});

--- a/tests/acceptance/embed-intent-test.js
+++ b/tests/acceptance/embed-intent-test.js
@@ -97,7 +97,7 @@ test('inserting unordered list at cursor', (assert) => {
         assert.hasElement('#editor ul li', 'adds a ul li');
         assert.equal($('#editor ul li').text(), '', 'li has no text');
 
-        Helpers.dom.insertText('X');
+        Helpers.dom.insertText(editor, 'X');
         assert.hasElement('#editor ul li:contains(X)', 'inserts text at correct spot');
 
         done();

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -161,8 +161,16 @@ function triggerEnter(editor) {
   }
 }
 
-function insertText(string) {
-  document.execCommand('insertText', false, string);
+function insertText(editor, string) {
+  if (!string && editor) { throw new Error('Must pass `editor` to `insertText`'); }
+
+  string.split('').forEach(letter => {
+    const keyEvent = {keyCode: letter.charCodeAt(0), preventDefault: () =>{}};
+    editor.triggerEvent(editor.element, 'keydown', keyEvent);
+    document.execCommand('insertText', false, letter);
+    editor.triggerEvent(editor.element, 'input');
+    editor.triggerEvent(editor.element, 'keyup', keyEvent);
+  });
 }
 
 const DOMHelper = {

--- a/tests/unit/parsers/section-test.js
+++ b/tests/unit/parsers/section-test.js
@@ -114,10 +114,3 @@ test('#parse joins contiguous text nodes separated by non-markup elements', (ass
 
   assert.equal(m1.value, 'span 1span 2');
 });
-
-// test: a section can parse dom
-
-// test: a section can clear a range:
-//   * truncating the markers on the boundaries
-//   * removing the intermediate markers
-//   * connecting (but not joining) the truncated boundary markers


### PR DESCRIPTION
  * Trigger is "space"
  * "*" -> ul>li
  * "1" and "1." -> ol>li
  * "##" -> h2
  * "###" -> h3

Adds `editor#registerExpansion` which takes an expansion.
An expansion has these keys:
  * `trigger` the keycode of the triggering key event. All of the existing ones use 32 ("space")
  * `text` the text that must match to the left of the cursor. Currently this only looks for text matching from the beginning of the section to the cursor. In the future it wouldn't be hard to modify it to handle in-context text, so you could bold text by adding "**" on either side of a word, perhaps
  * `run` a method that will get passed the `editor` instance when this expansion is triggered

fixes #87

![gpy](https://cloud.githubusercontent.com/assets/2023/9669092/24efd35e-5253-11e5-8fc2-3aa2e1fc8d42.gif)
