### PR TITLE
Cleanup listeners

### DIFF
--- a/src/js/utils/string-utils.js
+++ b/src/js/utils/string-utils.js
@@ -10,6 +10,10 @@ export function dasherize(string) {
   });
 }
 
+export function capitalize(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 export function startsWith(string, character) {
   return string.charAt(0) === character;
 }

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -146,7 +146,7 @@ function triggerDelete(editor) {
     let event = { preventDefault() {} };
     editor.handleDeletion(event);
   } else {
-    triggerKeyEvent(document, 'keydown', KEY_CODES.BACKSPACE);
+    triggerKeyEvent(editor.element, 'keydown', KEY_CODES.BACKSPACE);
   }
 }
 
@@ -157,7 +157,7 @@ function triggerEnter(editor) {
     let event = { preventDefault() {} };
     editor.handleNewline(event);
   } else {
-    triggerKeyEvent(document, 'keydown', KEY_CODES.ENTER);
+    triggerKeyEvent(editor.element, 'keydown', KEY_CODES.ENTER);
   }
 }
 


### PR DESCRIPTION
Simplify and DRY the event-listening code so that it's easier to turn on/off editability by squashing events in `handleEvent`