### PR TITLE
Handle blank mobiledoc in editor

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -88,10 +88,13 @@ var selfieCard = {
 var simpleCard = {
   name: 'simple-card',
   display: {
-    setup: function(element) {
+    setup: function(element, options, env) {
       var card = document.createElement('span');
       card.innerHTML = 'Hello, world';
       element.appendChild(card);
+      var button = $('<button>Remove card</button>');
+      button.on('click', env.remove);
+      $(element).append(button);
     }
   }
 };
@@ -284,6 +287,7 @@ function bootEditor(element, mobiledoc) {
   editor = new ContentKit.Editor({
     autofocus: false,
     mobiledoc: mobiledoc,
+    placeholder: 'Write something here...',
     cards: [simpleCard, cardWithEditMode, cardWithInput, selfieCard],
     cardOptions: {
       image: {
@@ -333,6 +337,14 @@ var sampleMobiledocs = {
           [[], 0, "hello world"]
         ]]
       ]
+    ]
+  },
+
+  emptyMobiledoc: {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      []
     ]
   },
 
@@ -408,9 +420,6 @@ var sampleMobiledocs = {
     sections: [
       [],
       [
-        [1, "H2", [
-          [[], 0, "Simple Card"]
-        ]],
         [10, "simple-card"]
       ]
     ]

--- a/demo/index.html
+++ b/demo/index.html
@@ -43,7 +43,9 @@
         <select id='select-mobiledoc'>
           <option disabled>Load a new Mobiledoc</option>
           <option value='simpleMobiledoc'>Simple text content</option>
+          <option value='emptyMobiledoc'>Empty mobiledoc</option>
           <option value='simpleMobiledocWithList'>List example</option>
+          <option value='mobileDocWithSimpleCard'>Simple Card</option>
           <option value='mobileDocWithInputCard'>Card with Input</option>
           <option value='mobileDocWithSelfieCard'>Selfie Card</option>
         </select>

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -8,7 +8,7 @@ import ImageCard from '../cards/image';
 import Key from '../utils/key';
 import EventEmitter from '../utils/event-emitter';
 
-import MobiledocParser from "../parsers/mobiledoc";
+import MobiledocParser from '../parsers/mobiledoc';
 import PostParser from '../parsers/post';
 import DOMParser from '../parsers/dom';
 import Renderer  from 'content-kit-editor/renderers/editor-dom';
@@ -234,7 +234,7 @@ class Editor {
   }
 
   handleNewline(event) {
-    if (!this.cursor.hasCursor()) { return ;}
+    if (!this.cursor.hasCursor()) { return; }
 
     const range = this.cursor.offsets;
     event.preventDefault();
@@ -570,8 +570,20 @@ class Editor {
     e.preventDefault(); // FIXME for now, just prevent default
   }
 
+  _insertEmptyMarkupSectionAtCursor() {
+    const section = this.run(postEditor => {
+      const section = postEditor.builder.createMarkupSection('p');
+      postEditor.insertSectionBefore(this.post.sections, section);
+      return section;
+    });
+    this.cursor.moveToSection(section);
+  }
+
   handleKeydown(event) {
     if (!this.isEditable) { return; }
+    if (this.post.isBlank) {
+      this._insertEmptyMarkupSectionAtCursor();
+    }
 
     const key = Key.fromEvent(event);
 

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1,4 +1,4 @@
-import { MARKUP_SECTION_TYPE, LIST_ITEM_TYPE } from '../models/types';
+import { POST_TYPE, MARKUP_SECTION_TYPE, LIST_ITEM_TYPE } from '../models/types';
 import Position from '../utils/cursor/position';
 import { filter, compact } from '../utils/array-utils';
 import { DIRECTION } from '../utils/key';
@@ -484,11 +484,20 @@ class PostEditor {
   }
 
   /**
+   * @method replaceSection
+   * @param {Section} section
+   * @param {Section} newSection
+   * @return null
    * @public
-   * FIXME: add tests for this
    */
   replaceSection(section, newSection) {
-    return this._replaceSection(section, [newSection]);
+    if (!section) {
+      // The section may be undefined if the user used the embed intent
+      // ("+" icon) to insert a new "ul" section in a blank post
+      this.insertSectionBefore(this.editor.post.sections, newSection);
+    } else {
+      this._replaceSection(section, [newSection]);
+    }
   }
 
   _replaceSection(section, newSections) {
@@ -597,7 +606,8 @@ class PostEditor {
    * @method insertSectionBefore
    * @param {LinkedList} collection The list of sections to insert into
    * @param {Object} section The new section
-   * @param {Object} beforeSection The section "before" is relative to
+   * @param {Object} beforeSection Optional The section "before" is relative to,
+   * if falsy the new section will be appended to the collection
    * @public
    */
   insertSectionBefore(collection, section, beforeSection) {
@@ -637,7 +647,7 @@ class PostEditor {
 
     parent.sections.remove(section);
 
-    if (parent.isBlank) {
+    if (parent.isBlank && parent.type !== POST_TYPE) {
       // If we removed the last child from a parent (e.g. the last li in a ul),
       // also remove the parent
       this.removeSection(parent);

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -1,4 +1,4 @@
-import { LIST_ITEM_TYPE, LIST_SECTION_TYPE } from './types';
+import { LIST_ITEM_TYPE } from './types';
 import { normalizeTagName } from '../utils/dom-utils';
 import LinkedItem from '../utils/linked-item';
 
@@ -6,12 +6,24 @@ function isMarkerable(section) {
   return !!section.markers;
 }
 
-function isListSection(section) {
-  return section.type === LIST_SECTION_TYPE;
+function getParentSection(section) {
+  return section.parent;
 }
 
-function isListItem(section) {
+function hasSubsections(section) {
+  return !!section.sections;
+}
+
+function isSubsection(section) {
   return section.type === LIST_ITEM_TYPE;
+}
+
+function firstMarkerableChild(section) {
+  return section.items.head;
+}
+
+function lastMarkerableChild(section) {
+  return section.items.tail;
 }
 
 export default class Section extends LinkedItem {
@@ -34,13 +46,13 @@ export default class Section extends LinkedItem {
     if (next) {
       if (isMarkerable(next)) {
         return next;
-      } else if (isListSection(next)) {
-        const firstListItem = next.items.head;
-        return firstListItem;
+      } else if (hasSubsections(next)) {
+        const firstChild = firstMarkerableChild(next);
+        return firstChild;
       }
-    } else if (isListItem(this)) {
-      const listSection = this.parent;
-      return listSection.immediatelyNextMarkerableSection();
+    } else if (isSubsection(this)) {
+      const parentSection = getParentSection(this);
+      return parentSection.immediatelyNextMarkerableSection();
     }
   }
 
@@ -49,9 +61,9 @@ export default class Section extends LinkedItem {
     if (!prev) { return null; }
     if (isMarkerable(prev)) {
       return prev;
-    } else if (isListSection(prev)) {
-      const lastListItem = prev.items.tail;
-      return lastListItem;
+    } else if (hasSubsections(prev)) {
+      const lastChild = lastMarkerableChild(prev);
+      return lastChild;
     }
   }
 }

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -12,6 +12,10 @@ export default class Post {
     });
   }
 
+  get isBlank() {
+    return this.sections.isEmpty;
+  }
+
   /**
    * @param {Range} range
    * @return {Array} markers that are completely contained by the range

--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -26,11 +26,6 @@ export default class MobiledocParser {
     this.markerTypes = this.parseMarkerTypes(markerTypes);
     this.parseSections(sections, post);
 
-    if (post.sections.isEmpty) {
-      let section = this.builder.createMarkupSection('p');
-      post.sections.append(section);
-    }
-
     return post;
   }
 

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -28,6 +28,8 @@ const Cursor = class Cursor {
   }
 
   isInCard() {
+    if (!this.hasCursor()) { return false; }
+
     const {head, tail} = this.offsets;
     return head && tail && (head._inCard || tail._inCard);
   }
@@ -40,7 +42,7 @@ const Cursor = class Cursor {
    * @return {Range} Cursor#Range object
    */
   get offsets() {
-    if (!this.hasCursor()) { return {}; }
+    if (!this.hasCursor()) { return Range.emptyRange(); }
 
     const { selection, renderTree } = this;
 

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -13,6 +13,10 @@ export default class Range {
     );
   }
 
+  static emptyRange() {
+    return new Range(Position.emptyPosition(), Position.emptyPosition());
+  }
+
   /**
    * @param {Markerable} section
    * @return {Range} A range that is constrained to only the part that

--- a/src/js/utils/dom-utils.js
+++ b/src/js/utils/dom-utils.js
@@ -71,14 +71,14 @@ function walkDOMUntil(topNode, conditionFn=() => {}) {
   }
 }
 
-// see https://github.com/webmodules/node-contains/blob/master/index.js
+/**
+ * @return {Boolean} true when the child node is contained by (and not
+ * the same as) the parent node
+ *  see https://github.com/webmodules/node-contains/blob/master/index.js
+ */
 function containsNode(parentNode, childNode) {
-  const isSame = () => parentNode === childNode;
-  const isContainedBy = () => {
-    const position = parentNode.compareDocumentPosition(childNode);
-    return !!(position & Node.DOCUMENT_POSITION_CONTAINED_BY);
-  };
-  return isSame() || isContainedBy();
+  const position = parentNode.compareDocumentPosition(childNode);
+  return !!(position & Node.DOCUMENT_POSITION_CONTAINED_BY);
 }
 
 /**
@@ -125,6 +125,29 @@ function normalizeTagName(tagName) {
   return tagName.toLowerCase();
 }
 
+/*
+ * @param {Node} elementNode not a text node
+ * @param {Node} textNode a text node
+ * @param {Number} offsetInTextNode optional, the offset relative to the text node
+ * @return {Number} The offset relative to all the text nodes in the element node
+ */
+function findOffsetInElement(elementNode, textNode, offsetInTextNode=0) {
+  let offset = 0, found = false;
+  walkTextNodes(elementNode, _textNode => {
+    if (found) { return; }
+    if (_textNode === textNode) {
+      found = true;
+      offset += offsetInTextNode;
+    } else {
+      offset += _textNode.textContent.length;
+    }
+  });
+  if (!found) {
+    throw new Error('Unable to find offset of text node in element, it is not a child.');
+  }
+  return offset;
+}
+
 function parseHTML(html) {
   var div = document.createElement('div');
   div.innerHTML = html;
@@ -144,5 +167,6 @@ export {
   removeClassName,
   normalizeTagName,
   isTextNode,
-  parseHTML
+  parseHTML,
+  findOffsetInElement
 };

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -1,7 +1,7 @@
 import { Editor } from 'content-kit-editor';
 import Helpers from '../test-helpers';
 
-const { test, module } = QUnit;
+const { test, module } = Helpers;
 
 let fixture, editor, editorElement;
 
@@ -59,6 +59,7 @@ test('#disableEditing and #enableEditing toggle contenteditable', (assert) => {
 });
 
 test('clicking outside the editor does not raise an error', (assert) => {
+  const done = assert.async();
   editor = new Editor({autofocus: false});
   editor.render(editorElement);
 
@@ -73,11 +74,26 @@ test('clicking outside the editor does not raise an error', (assert) => {
   // Embed intent uses setTimeout, so this assertion must
   // setTimeout after it to catch the exception during failure
   // cases.
-  let done = assert.async();
   setTimeout(() => {
     assert.ok(true, 'can click external item without error');
-    done();
     secondEditor.destroy();
     document.body.removeChild(secondEditorElement);
-  }, 1);
+
+    done();
+  });
+});
+
+test('typing in empty post correctly adds a section to it', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post}) => post());
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  assert.hasElement('#editor');
+  assert.hasNoElement('#editor p');
+
+  Helpers.dom.moveCursorTo($('#editor')[0]);
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasElement('#editor p:contains(X)');
+  Helpers.dom.insertText(editor, 'Y');
+  assert.hasElement('#editor p:contains(XY)', 'inserts text at correct spot');
 });

--- a/tests/acceptance/editor-cards-test.js
+++ b/tests/acceptance/editor-cards-test.js
@@ -92,3 +92,34 @@ test('editor listeners are quieted for card actions', (assert) => {
     done();
   });
 });
+
+test('removing last card from mobiledoc allows additional editing', (assert) => {
+  const done = assert.async();
+  let button;
+  const cards = [{
+    name: 'simple-card',
+    display: {
+      setup(element, options, env) {
+        button = $('<button>Click me</button>');
+        button.on('click', env.remove);
+        $(element).append(button);
+      }
+    }
+  }];
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  assert.hasElement('#editor button:contains(Click me)', 'precond - button');
+
+  button.click();
+
+  setTimeout(() => {
+    assert.hasNoElement('#editor button:contains(Click me)', 'button is removed');
+    assert.hasNoElement('#editor p');
+    Helpers.dom.moveCursorTo($('#editor')[0]);
+    Helpers.dom.insertText(editor, 'X');
+    assert.hasElement('#editor p:contains(X)');
+
+    done();
+  });
+});

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -210,6 +210,7 @@ test('hitting enter at empty last list item exists list', (assert) => {
   assert.equal($('#editor li').length, 2, 'removes empty li');
   assert.equal($('#editor p').length, 1, 'adds 1 new p');
   assert.equal($('#editor p').text(), '', 'p has no text');
+  assert.hasNoElement('#editor ul p', 'does not nest p under ul');
 
   Helpers.dom.insertText(editor, 'X');
   assert.hasElement('#editor p:contains(X)', 'text goes in right spot');

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -3,12 +3,7 @@ import Range from 'content-kit-editor/utils/cursor/range';
 
 const {module, test} = Helpers;
 
-module('Unit: Post', {
-  beforeEach() {
-  },
-  afterEach() {
-  }
-});
+module('Unit: Post');
 
 test('#markersFrom finds markers across markup sections', (assert) => {
   const post = Helpers.postAbstract.build(({post, markupSection, marker}) =>
@@ -269,4 +264,15 @@ test('#markersContainedByRange when range is contiguous sections', (assert) => {
   assert.equal(found.length,
                headSection.markers.length + tailSection.markers.length,
                'all markers in outerRange');
+});
+
+test('#isBlank is true when there are no sections', (assert) => {
+  let _post, _section;
+  Helpers.postAbstract.build(({post, markupSection}) => {
+    _post = post();
+    _section = markupSection();
+  });
+  assert.ok(_post.isBlank);
+  _post.sections.append(_section);
+  assert.ok(!_post.isBlank);
 });

--- a/tests/unit/parsers/mobiledoc-test.js
+++ b/tests/unit/parsers/mobiledoc-test.js
@@ -21,29 +21,26 @@ module('Unit: Parsers: Mobiledoc', {
 });
 
 test('#parse empty doc returns an empty post', (assert) => {
-  let mobiledoc = {
+  const mobiledoc = {
     version: MOBILEDOC_VERSION,
     sections: [[], []]
   };
 
-  let section = builder.createMarkupSection('P');
-  post.sections.append(section);
-  assert.deepEqual(parser.parse(mobiledoc),
-                   post);
+  const parsed = parser.parse(mobiledoc);
+  assert.equal(parsed.sections.length, 0, '0 sections');
 });
 
 test('#parse empty markup section returns an empty post', (assert) => {
-  let mobiledoc = {
+  const mobiledoc = {
     version: MOBILEDOC_VERSION,
     sections: [[], [
-      [1, 'h2', []]
+      [1, 'p', []]
     ]]
   };
 
-  let section = builder.createMarkupSection('h2');
+  const section = builder.createMarkupSection('p');
   post.sections.append(section);
-  assert.deepEqual(parser.parse(mobiledoc),
-                   post);
+  assert.deepEqual(parser.parse(mobiledoc), post);
 });
 
 test('#parse doc without marker types', (assert) => {


### PR DESCRIPTION
This removes some code that previously forced an empty mobiledoc to
have a single empty section in it. A mobiledoc can now be truly empty and
the editor will display it and respond to events correctly.

Added `Post#isBlank` and in the keydown listener, if the post is blank the
editor will insert a new empty markup section under the cursor.

Now that it is possible to have a fully empty mobiledoc, the css for showing
the placeholder will apply again. We currently stop a "backspace" keystroke if
it is at the beginning of the first markup section, so it is not possible to use
the keyboard to make a post completely blank, but it's possible to do so by removing
a card from the editor if the card was the only thing there.

Updated the demo.js with a removable card demo and an empty mobiledoc demo
so that the two scenarios described above are viable to test and see the
placeholder text rendered.

Added some additional handling for the embed intent (the "+" icon that shows up)
to ensure that it does not throw errors and that it does show up when the 
editor is showing an empty mobiledoc.

 * Rename Section methods semantically
 * add "simple-card" demo, with "remove" button
 * Clean up cursor detection and embedIntent
 * Add Position.emptyPosition and Range.emptyRange
 * allow mobiledoc to have 0 sections
 * add Post#isBlank
 * Add tests for typing in blank mobiledoc
 * Tests for removing the last item (e.g., card) in a mobiledoc
 * Ensure that replaceSection works when section is undefined
 * Add empty mobiledoc to demo

fixes #125 #35 #71