### PR TITLE
refactor renderer to avoid memory leak when child render nodes were not removed

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -88,7 +88,7 @@ class Editor {
     this._renderer = new Renderer(this, this.cards, this.unknownCardHandler, this.cardOptions);
 
     this.post = this.loadPost();
-    this._renderTree = this.prepareRenderTree(this.post);
+    this._renderTree = new RenderTree(this.post);
   }
 
   addView(view) {
@@ -98,13 +98,6 @@ class Editor {
   get builder() {
     if (!this._builder) { this._builder = new PostNodeBuilder(); }
     return this._builder;
-  }
-
-  prepareRenderTree(post) {
-    let renderTree = new RenderTree();
-    let node = renderTree.buildRenderNode(post);
-    renderTree.node = node;
-    return renderTree;
   }
 
   loadPost() {

--- a/src/js/models/render-tree.js
+++ b/src/js/models/render-tree.js
@@ -2,20 +2,38 @@ import RenderNode from 'content-kit-editor/models/render-node';
 import ElementMap from "../utils/element-map";
 
 export default class RenderTree {
-  constructor(node) {
-    this.node = node;
-    this.elements = new ElementMap();
+  constructor(rootPostNode) {
+    this._rootNode = this.buildRenderNode(rootPostNode);
+    this._elements = new ElementMap();
   }
+  /*
+   * @return {RenderNode} The root render node in this tree
+   */
+  get rootNode() {
+    return this._rootNode;
+  }
+  /*
+   * @return {DOMNode} The root DOM element in this tree
+   */
   get rootElement() {
-    return this.node.element;
+    return this.rootNode.element;
   }
+  /*
+   * @param {DOMNode} element
+   * @return {RenderNode} The renderNode for this element, if any
+   */
   getElementRenderNode(element) {
-    return this.elements.get(element);
+    return this._elements.get(element);
   }
-  buildRenderNode(section) {
-    let renderNode = new RenderNode(section);
-    renderNode.renderTree = this;
-    section.renderNode = renderNode;
+  setElementRenderNode(element, renderNode) {
+    this._elements.set(element, renderNode);
+  }
+  removeElementRenderNode(element) {
+    this._elements.remove(element);
+  }
+  buildRenderNode(postNode) {
+    const renderNode = new RenderNode(postNode, this);
+    postNode.renderNode = renderNode;
     return renderNode;
   }
 }

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -110,7 +110,6 @@ export default class PostParser {
 
         renderNode = renderTree.buildRenderNode(marker);
         renderNode.element = textNode;
-        renderNode.renderTree.elements.set(textNode, renderNode);
         renderNode.markClean();
 
         let previousRenderNode = previousMarker && previousMarker.renderNode;

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -31,17 +31,10 @@ function postEditorWithMobiledoc(treeFn) {
   return new PostEditor(editor);
 }
 
-function prepareRenderTree(post) {
-  let renderTree = new RenderTree();
-  let node = renderTree.buildRenderNode(post);
-  renderTree.node = node;
-  return renderTree;
-}
-
 function renderBuiltAbstract(post) {
   mockEditor.post = post;
   let renderer = new EditorDomRenderer(mockEditor, [], () => {}, {});
-  let renderTree = prepareRenderTree(post);
+  let renderTree = new RenderTree(post);
   renderer.render(renderTree);
 }
 


### PR DESCRIPTION
This changes the `RenderTree` to accept a root post node in its constructor.

All building of render nodes now goes through `renderTree#buildRenderNode`. These two changes remove a lot of the boilerplate that used to be involved when setting up a render tree or creating new render nodes.

Changes the `childNodes#remove` callback for `renderNode` to set more of the render node's properties to null, as well as clear its element from the element map (this was the source of the memory leak).