### PR TITLE
Ensure that a markup can be applied to a range with a blank section

### DIFF
--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -87,6 +87,27 @@ export default class Markerable extends Section {
     throw new Error('splitAtMarker must be implemented by sub-class');
   }
 
+  /**
+   * Split this section's marker (if any) at the given offset, so that
+   * there is now a marker boundary at that offset (useful for later applying
+   * a markup to a range)
+   * @param {Number} sectionOffset The offset relative to start of this section
+   * @return {EditObject} An edit object with 'removed' and 'added' keys with arrays of Markers
+   */
+  splitMarkerAtOffset(sectionOffset) {
+    const edit = {removed:[], added:[]};
+    const {marker,offset} = this.markerPositionAtOffset(sectionOffset);
+    if (!marker) { return edit; }
+
+    const newMarkers = filter(marker.split(offset), m => !m.isEmpty);
+    this.markers.splice(marker, 1, newMarkers);
+
+    edit.removed = [marker];
+    edit.added = newMarkers;
+
+    return edit;
+  }
+
   splitAtPosition(position) {
     const {marker, offsetInMarker} = position;
     return this.splitAtMarker(marker, offsetInMarker);

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -512,3 +512,34 @@ test('selecting text that includes a 1-character marker and unbolding it', (asse
     done();
   });
 });
+
+// see https://github.com/bustlelabs/content-kit-editor/issues/128
+test('selecting text that includes an empty section and applying markup to it', (assert) => {
+  const done = assert.async();
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p')
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  // precond
+  assert.hasElement('#editor p:contains(abc)');
+  assert.ok($('#editor p:eq(1)').text() === '', 'no text in second p');
+  const t1 = $('#editor p:eq(0)')[0].childNodes[0];
+  assert.equal(t1.textContent, 'abc', 'correct text node');
+  const p2 = $('#editor p:eq(1)')[0];
+
+  Helpers.dom.moveCursorTo(t1, 0, p2, 0);
+  Helpers.dom.triggerEvent(document, 'mouseup');
+
+  setTimeout(() => {
+    assert.toolbarVisible();
+    Helpers.toolbar.clickButton(assert, 'bold');
+
+    assert.hasElement('#editor p strong:contains(abc)', 'bold is applied to text');
+    done();
+  });
+});


### PR DESCRIPTION
When a range ended in a blank section there was no tailMarker for that
range, causing some issues specifically around postEditor#splitMarkers

  * Add #splitMarkerAtOffset method to markerables, refactor
    postEditor#splitMarkers to use it
  * Add #_markDirty and #_scheduleForRemoval to postEditor
  * refactor to only call `scheduleDidUpdate` and `scheduleRerender` in
    postEditor after marking something dirty or for removal

fixes #128