### PR TITLE
Add postEditor#insertSection, #insertSectionAtEnd, #toggleMarkup

### DIFF
--- a/src/js/commands/link.js
+++ b/src/js/commands/link.js
@@ -1,5 +1,4 @@
 import TextFormatCommand from './text-format';
-import { any }  from 'content-kit-editor/utils/array-utils';
 
 export default class LinkCommand extends TextFormatCommand {
   constructor(editor) {
@@ -10,24 +9,10 @@ export default class LinkCommand extends TextFormatCommand {
     });
   }
 
-  isActive() {
-    return any(this.editor.markupsInSelection, m => m.hasTag(this.tag));
-  }
-
   exec(url) {
-    const range = this.editor.cursor.offsets;
     this.editor.run(postEditor => {
       const markup = postEditor.builder.createMarkup('a', ['href', url]);
-      postEditor.applyMarkupToRange(range, markup);
+      this.editor.run(postEditor => postEditor.toggleMarkup(markup));
     });
-    this.editor.moveToPosition(range.tail);
-  }
-
-  unexec() {
-    const range = this.editor.cursor.offsets;
-    this.editor.run(postEditor => {
-      postEditor.removeMarkupFromRange(range, markup => markup.hasTag('a'));
-    });
-    this.editor.selectRange(range);
   }
 }

--- a/src/js/commands/text-format.js
+++ b/src/js/commands/text-format.js
@@ -8,27 +8,15 @@ export default class TextFormatCommand extends Command {
     this.tag = options.tag;
   }
 
-  get markup() {
-    if (this._markup) { return this._markup; }
-    this._markup = this.editor.builder.createMarkup(this.tag);
-    return this._markup;
-  }
-
   isActive() {
-    return any(this.editor.markupsInSelection, m => m === this.markup);
+    return any(this.editor.markupsInSelection, m => m.hasTag(this.tag));
   }
 
   exec() {
-    const range = this.editor.cursor.offsets, { markup } = this;
-    this.editor.run(
-      postEditor => postEditor.applyMarkupToRange(range, markup));
-    this.editor.selectRange(range);
+    this.editor.run(postEditor => postEditor.toggleMarkup(this.tag));
   }
 
   unexec() {
-    const range = this.editor.cursor.offsets, { markup } = this;
-    this.editor.run(
-      postEditor => postEditor.removeMarkupFromRange(range, markup));
-    this.editor.selectRange(range);
+    this.editor.run(postEditor => postEditor.toggleMarkup(this.tag));
   }
 }

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -367,6 +367,11 @@ class Editor {
     return this.cursor.activeSections;
   }
 
+  get activeSection() {
+    const { activeSections } = this;
+    return activeSections[activeSections.length - 1];
+  }
+
   get markupsInSelection() {
     if (this.cursor.hasSelection()) {
       const range = this.cursor.offsets;

--- a/tests/acceptance/editor-commands-test.js
+++ b/tests/acceptance/editor-commands-test.js
@@ -232,19 +232,7 @@ Helpers.skipInPhantom('highlight text, click "link" button shows input for URL, 
 
     setTimeout(() => {
       assert.hasElement(`#editor a[href="${url}"]:contains(${selectedText})`);
-
-      Helpers.dom.insertText(editor, 'X');
-
-      assert.hasElement(`#editor p:contains(${selectedText}X)`,
-                        'inserts text after selected text');
-      assert.hasNoElement(`#editor a:contains(${selectedText}X)`,
-                        'inserted text does not extend "a" tag');
-
-      Helpers.dom.insertText(editor, 'X');
-      assert.hasElement(`#editor p:contains(${selectedText}XX)`,
-                        'inserts text after selected text again');
-
-      Helpers.dom.selectText(selectedText, editorElement);
+      assert.selectedText(selectedText, 'text remains selected');
       Helpers.dom.triggerEvent(document, 'mouseup');
 
       setTimeout(() => {

--- a/tests/acceptance/editor-post-editor-test.js
+++ b/tests/acceptance/editor-post-editor-test.js
@@ -1,0 +1,119 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+
+const { module, test } = Helpers;
+
+let editor, editorElement;
+
+module('Acceptance: Editor - PostEditor', {
+  beforeEach() {
+    editorElement = $('<div id="editor"></div>')[0];
+    $('#qunit-fixture').append($(editorElement));
+  },
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('#insertSectionAtEnd inserts the section at the end', (assert) => {
+  let newSection;
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    newSection = markupSection('p', [marker('123')]);
+    return post([markupSection('p', [marker('abc')])]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  //precond
+  assert.hasElement('#editor p:contains(abc)');
+  assert.hasNoElement('#editor p:contains(123)');
+
+  editor.run(postEditor => postEditor.insertSectionAtEnd(newSection));
+  assert.hasElement('#editor p:eq(1):contains(123)', 'new section added at end');
+});
+
+test('#insertSection inserts after the cursor active section', (assert) => {
+  let newSection;
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    newSection = markupSection('p', [marker('123')]);
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('def')])
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  //precond
+  assert.hasElement('#editor p:eq(0):contains(abc)');
+  assert.hasElement('#editor p:eq(1):contains(def)');
+  assert.hasNoElement('#editor p:contains(123)');
+
+  Helpers.dom.selectText('b', editorElement);
+
+  editor.run(postEditor => postEditor.insertSection(newSection));
+  assert.hasElement('#editor p:eq(0):contains(abc)', 'still has 1st section');
+  assert.hasElement('#editor p:eq(1):contains(123)',
+                    'new section added after active section');
+  assert.hasElement('#editor p:eq(2):contains(def)', '2nd section -> 3rd spot');
+});
+
+test('#insertSection inserts at end when no active cursor section', (assert) => {
+  let newSection;
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    newSection = markupSection('p', [marker('123')]);
+    return post([
+      markupSection('p', [marker('abc')]),
+      markupSection('p', [marker('def')])
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  //precond
+  assert.hasElement('#editor p:eq(0):contains(abc)');
+  assert.hasElement('#editor p:eq(1):contains(def)');
+  assert.hasNoElement('#editor p:contains(123)');
+
+  Helpers.dom.clearSelection();
+  editor.run(postEditor => postEditor.insertSection(newSection));
+  assert.hasElement('#editor p:eq(0):contains(abc)', 'still has 1st section');
+  assert.hasElement('#editor p:eq(2):contains(123)', 'new section added at end');
+  assert.hasElement('#editor p:eq(1):contains(def)', '2nd section -> same spot');
+});
+
+test('#toggleMarkup adds markup by tag name', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [marker('abc'), marker('def')])
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  //precond
+  assert.hasNoElement('#editor strong');
+
+  Helpers.dom.selectText('bc', editorElement, 'd', editorElement);
+  editor.run(postEditor => postEditor.toggleMarkup('strong'));
+  assert.hasElement('#editor strong:contains(bcd)');
+});
+
+test('#toggleMarkup removes markup by tag name', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker, markup}) => {
+    const strong = markup('strong');
+    return post([
+      markupSection('p', [marker('a'), marker('bcde', [strong]), marker('f')])
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  //precond
+  assert.hasElement('#editor strong:contains(bcde)');
+
+  Helpers.dom.selectText('bc', editorElement, 'd', editorElement);
+  editor.run(postEditor => postEditor.toggleMarkup('strong'));
+  assert.hasNoElement('#editor strong:contains(bcd)', 'markup removed from selection');
+  assert.hasElement('#editor strong:contains(e)', 'unselected text still bold');
+});

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -581,3 +581,18 @@ test('#replaceSection when section is null appends new section', (assert) => {
   assert.equal(post.sections.length, 1, 'has 1 section');
   assert.equal(post.sections.head.text, '', 'no text in new section');
 });
+
+test('#insertSectionAtEnd inserts the section at the end of the mobiledoc', (assert) => {
+  let newSection;
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    newSection = markupSection('p', [marker('123')]);
+    return post([markupSection('p', [marker('abc')])]);
+  });
+  renderBuiltAbstract(post);
+
+  postEditor.insertSectionAtEnd(newSection);
+  postEditor.complete();
+
+  assert.equal(post.sections.length, 2, 'new section added');
+  assert.equal(post.sections.tail.text, '123', 'new section added at end');
+});


### PR DESCRIPTION
Sample usage:

```
// insert a section at the end of the document
const section = builder.createCardSection('my-card');
editor.run(postEditor => postEditor.insertSectionAtEnd(section));
```

```
// toggle 'strong' markup on the text the user has selected
editor.run(postEditor => postEditor.toggleMarkup('strong'));
```

fixes #126