### PR TITLE
Use postEditor for block format commands

### DIFF
--- a/src/js/commands/format-block.js
+++ b/src/js/commands/format-block.js
@@ -11,30 +11,25 @@ class FormatBlockCommand extends TextFormatCommand {
   }
 
   exec() {
-    const editor = this.editor;
-    const activeSections = editor.activeSections;
-
-    activeSections.forEach(s => {
-      editor.resetSectionMarkers(s);
-      editor.setSectionTagName(s, this.tag);
+    const { editor } = this;
+    editor.run(postEditor => {
+      const activeSections = editor.activeSections;
+      activeSections.forEach(s => postEditor.changeSectionTagName(s, this.tag));
+      postEditor.scheduleAfterRender(() => {
+        editor.selectSections(activeSections);
+      });
     });
-
-    editor.rerender();
-    editor.selectSections(activeSections);
-    this.editor.didUpdate();
   }
 
   unexec() {
-    const editor = this.editor;
-    const activeSections = editor.activeSections;
-
-    activeSections.forEach(s => {
-      editor.resetSectionTagName(s);
+    const { editor } = this;
+    editor.run(postEditor => {
+      const activeSections = editor.activeSections;
+      activeSections.forEach(s => postEditor.resetSectionTagName(s));
+      postEditor.scheduleAfterRender(() => {
+        editor.selectSections(activeSections);
+      });
     });
-
-    editor.rerender();
-    editor.selectSections(activeSections);
-    this.editor.didUpdate();
   }
 }
 

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -371,29 +371,6 @@ class Editor {
     }
   }
 
-  /*
-   * Clear the markups from each of the section's markers
-   */
-  resetSectionMarkers(section) {
-    section.markers.forEach(m => {
-      m.clearMarkups();
-      m.renderNode.markDirty();
-    });
-  }
-
-  /*
-   * Change the tag name for the given section
-   */
-  setSectionTagName(section, tagName) {
-    section.setTagName(tagName);
-    section.renderNode.markDirty();
-  }
-
-  resetSectionTagName(section) {
-    section.resetTagName();
-    section.renderNode.markDirty();
-  }
-
   _reparseCurrentSection() {
     const {headSection:currentSection } = this.cursor.offsets;
     this._parser.reparseSection(currentSection, this._renderTree);

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1,3 +1,6 @@
+import {
+  DEFAULT_TAG_NAME as DEFAULT_MARKUP_SECTION_TAG_NAME
+} from '../models/markup-section';
 import { POST_TYPE, MARKUP_SECTION_TYPE, LIST_ITEM_TYPE } from '../models/types';
 import Position from '../utils/cursor/position';
 import { any, filter, compact } from '../utils/array-utils';
@@ -594,6 +597,19 @@ class PostEditor {
       this.applyMarkupToRange(range, markup);
     }
     this.scheduleAfterRender(() => this.editor.selectRange(range));
+  }
+
+  changeSectionTagName(section, newTagName) {
+    section.markers.forEach(m => {
+      m.clearMarkups();
+      this._markDirty(m);
+    });
+    section.setTagName(newTagName);
+    this._markDirty(section);
+  }
+
+  resetSectionTagName(section) {
+    this.changeSectionTagName(section, DEFAULT_MARKUP_SECTION_TAG_NAME);
   }
 
   /**


### PR DESCRIPTION
Move `changeSectionTagName` and `resetSectionTagName` to postEditor,
change block format commands to use `editor#run` instead of accessing
editor directly.