### PR TITLE
Coalesce markers that have identical markups

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ editor.didUpdatePost(postEditor => {
 
 The available lifecycle hooks are:
 
-* `editor.didUpdatePost(postEditor => {})` - An opprotunity to use the
+* `editor.didUpdatePost(postEditor => {})` - An opportunity to use the
   `postEditor` and possibly change the post before rendering begins.
 * `editor.willRender()` - After all post mutation has finished, but before
    the DOM is updated.
@@ -107,13 +107,11 @@ the creation of completely custom interfaces for buttons, hot-keys, and
 other interactions.
 
 To change the post in code, use the `editor.run` API. For example, the
-following usage would mark currently selected text as bold:
+following usage would mark currently selected text as "strong":
 
 ```js
-const strongMarkup = editor.builder.createMarkup('strong');
-const range = editor.cursor.offsets;
-editor.run((postEditor) => {
-  postEditor.applyMarkupToRange(range, strongMarkup);
+editor.run(postEditor => {
+  postEditor.toggleMarkup('strong');
 });
 ```
 
@@ -121,10 +119,10 @@ It is important that you make changes to posts, sections, and markers through
 the `run` and `postEditor` API. This API allows Content-Kit to conserve
 and better understand changes being made to the post.
 
-For more details on the API of `postEditor`, see the [API documentation](https://github.com/mixonic/content-kit-editor/blob/master/src/js/editor/post.js).
+For more details on the API of `postEditor`, see the [API documentation](https://github.com/bustlelabs/content-kit-editor/blob/master/src/js/editor/post.js).
 
 For more details on the API for the builder, required to create new sections
-and markers, see the [builder API](https://github.com/mixonic/content-kit-editor/blob/master/src/js/models/post-node-builder.js).
+and markers, see the [builder API](https://github.com/bustlelabs/content-kit-editor/blob/master/src/js/models/post-node-builder.js).
 
 ### Contributing
 

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -224,10 +224,10 @@ class Editor {
   handleNewline(event) {
     if (!this.cursor.hasCursor()) { return; }
 
-    const range = this.cursor.offsets;
     event.preventDefault();
 
-    const cursorSection = this.run((postEditor) => {
+    const range = this.cursor.offsets;
+    const cursorSection = this.run(postEditor => {
       if (!range.isCollapsed) {
         postEditor.deleteRange(range);
         if (range.head.section.isBlank) {
@@ -262,9 +262,8 @@ class Editor {
 
   cancelSelection() {
     if (this._hasSelection) {
-      // FIXME perhaps restore cursor position to end of the selection?
-      this.cursor.clearSelection();
-      this.reportNoSelection();
+      const range = this.cursor.offsets;
+      this.moveToPosition(range.tail);
     }
   }
 
@@ -339,6 +338,8 @@ class Editor {
     this.cursor.moveToSection(headSection, headSectionOffset);
   }
 
+  // FIXME this should be able to be removed now -- if any sections are detached,
+  // it's due to a bug in the code.
   _removeDetachedSections() {
     forEach(
       filter(this.post.sections, s => !s.renderNode.isAttached()),

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -10,9 +10,11 @@ function detect(enumerable, callback) {
   }
 }
 
-function any(array, callback) {
-  for (let i=0; i<array.length; i++) {
-    if (callback(array[i])) {
+function any(enumerable, callback) {
+  if (enumerable.any) { return enumerable.any(callback); }
+
+  for (let i=0; i<enumerable.length; i++) {
+    if (callback(enumerable[i])) {
       return true;
     }
   }
@@ -92,6 +94,17 @@ function objectToSortedKVArray(obj) {
   return result;
 }
 
+// check shallow equality of two non-nested arrays
+function isArrayEqual(arr1, arr2) {
+  let l1 = arr1.length, l2 = arr2.length;
+  if (l1 !== l2) { return false; }
+
+  for (let i=0; i < l1; i++) {
+    if (arr1[i] !== arr2[i]) { return false; }
+  }
+  return true;
+}
+
 export {
   detect,
   forEach,
@@ -101,5 +114,6 @@ export {
   compact,
   reduce,
   objectToSortedKVArray,
-  kvArrayToObject
+  kvArrayToObject,
+  isArrayEqual
 };

--- a/src/js/utils/linked-list.js
+++ b/src/js/utils/linked-list.js
@@ -139,6 +139,9 @@ export default class LinkedList {
       item = item.next;
     }
   }
+  any(callback) {
+    return !!this.detect(callback);
+  }
   objectAt(targetIndex) {
     let index = -1;
     return this.detect(() => {

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -63,8 +63,8 @@ test('selecting an entire section and deleting removes it', (assert) => {
   Helpers.dom.selectText('second section', editorElement);
   Helpers.dom.triggerDelete(editor);
 
-  assert.hasElement('p:contains(first section)');
-  assert.hasNoElement('p:contains(second section)', 'deletes contents of second section');
+  assert.hasElement('#editor p:contains(first section)');
+  assert.hasNoElement('#editor p:contains(second section)', 'deletes contents of second section');
   assert.equal($('#editor p').length, 2, 'still has 2 sections');
 
   Helpers.dom.insertText(editor, 'X');
@@ -81,16 +81,12 @@ test('selecting text in a section and deleting deletes it', (assert) => {
   Helpers.dom.selectText('cond sec', editorElement);
   Helpers.dom.triggerDelete(editor);
 
-  assert.hasElement('p:contains(first section)', 'first section unchanged');
-  assert.hasNoElement('p:contains(second section)', 'second section is no longer there');
-  assert.hasElement('p:contains(setion)', 'second section has correct text');
+  assert.hasElement('#editor p:contains(first section)', 'first section unchanged');
+  assert.hasNoElement('#editor p:contains(second section)', 'second section is no longer there');
+  assert.hasElement('#editor p:contains(setion)', 'second section has correct text');
 
-  let textNode = $('p:contains(setion)')[0].childNodes[0];
-  assert.equal(textNode.textContent, 'se', 'precond - has correct text node');
-  let charOffset = 2; // after the 'e' in 'se'
-
-  assert.deepEqual(Helpers.dom.getCursorPosition(),
-                   {node: textNode, offset: charOffset});
+  Helpers.dom.insertText(editor, 'Z');
+  assert.hasElement('#editor p:contains(seZtion)', 'text inserted correctly');
 });
 
 test('selecting text across sections and deleting joins sections', (assert) => {


### PR DESCRIPTION
This prevents some drift in the mobiledoc that comes with a lot of
editing. Prior to this, when contiguous markers were changed so that their
markups were identical, they continued to be stored as separate
markers (and rendered as contiguous textNodes). The resulted in a messy
rendered mobiledoc, with many vacuously similar markers.

Keeping markers coordinated should also reduce memory pressure in large
documents.