### PR TITLE
add `cursorDidChange` lifecycle hook to editor, called when cursor position changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The available lifecycle hooks are:
    the DOM is updated.
 * `editor.didRender()` - After the DOM has been updated to match the
   edited post.
+* `editor.cursorDidChange()` - When the cursor (or selection) changes as a result of arrow-key
+  movement or clicking in the document.
 
 ### Programmatic Post Editing
 

--- a/src/js/utils/lifecycle-callbacks.js
+++ b/src/js/utils/lifecycle-callbacks.js
@@ -1,0 +1,20 @@
+import { forEach } from './array-utils';
+
+export default class LifecycleCallbacksMixin {
+  get callbackQueues() {
+    if (!this._callbackQueues) { this._callbackQueues = {}; }
+    return this._callbackQueues;
+  }
+  runCallbacks(queueName, args=[]) {
+    if (!queueName) { throw new Error('Must pass queue name to runCallbacks'); }
+    const callbacks = this.callbackQueues[queueName] || [];
+    forEach(callbacks, cb => cb(...args));
+  }
+  addCallback(queueName, callback) {
+    if (!queueName) { throw new Error('Must pass queue name to addCallback'); }
+    if (!this.callbackQueues[queueName]) {
+      this.callbackQueues[queueName] = [];
+    }
+    this.callbackQueues[queueName].push(callback);
+  }
+}

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -171,6 +171,12 @@ function triggerKeyCommand(editor, string, modifier) {
   editor.triggerEvent(editor.element, 'keydown', keyEvent);
 }
 
+function triggerRightArrowKey(editor) {
+  if (!editor) { throw new Error('Must pass editor to triggerRightArrowKey'); }
+  const event = {preventDefault() {}, keyCode: 39};
+  editor.triggerEvent(editor.element, 'keyup', event);
+}
+
 const DOMHelper = {
   moveCursorTo,
   selectText,
@@ -185,7 +191,8 @@ const DOMHelper = {
   triggerForwardDelete,
   triggerEnter,
   insertText,
-  triggerKeyCommand
+  triggerKeyCommand,
+  triggerRightArrowKey
 };
 
 export { triggerEvent };


### PR DESCRIPTION
The editor runs these callbacks after the selection changes as result of a mouseup or keyup event.
fixes #157

As written now, this doesn't guarantee that the callbacks run once-and-only-once when the cursor moves, and also doesn't guarantee that the cursor did actually change position.

As implemented, though, this is enough for a UI element (like a toolbar button)
to stay up to date as the user selects, clicks, or arrows through the text.
Improving cursor position tracking to not fire on, say, multiple clicks in the 
exact same location would be nice, but does not seem like a critical requirement
for a first iteration of this event.

cc @mixonic 