### PR TITLE
Add postEditor#moveSectionUp, postEditor#moveSectionDown

### DIFF
--- a/CARDS.md
+++ b/CARDS.md
@@ -66,7 +66,8 @@ var exampleCard = {
   The content for the card should be pushed on that array as a string.
 * `options` is the `cardOptions` argument passed to the editor or renderer.
 * `env` contains information about the running of this hook. It may contain
-  the following functions:
+  the following properties:
+  * `env.name` The name of this card
   * `env.save(payload)` will save a new payload for a card instance, then
     swap a card in edit mode to display.
   * `env.cancel()` will swap a card in edit mode to display without changing
@@ -76,6 +77,9 @@ var exampleCard = {
   * `env.remove()` remove this card. This calls the current mode's `teardown()`
     hook and removes the card from DOM and from the post abstract.
     the instance to edit mode.
+  * `env.section` the CardSection from the Post -- this can be used when
+    programmatically interacting with the card, for example to move the card
+    using `editor.run(postEditor => postEditor.moveSectionUp(section)`.
 * `payload` is the payload for this card instance. It was either loaded from
   a Mobiledoc or generated and passed into an `env.save` call.
 

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -108,7 +108,7 @@ class Editor {
       }
       return new DOMParser(this.builder).parse(this.html);
     } else {
-      return this.builder.createBlankPost();
+      return this.builder.createPost();
     }
   }
 

--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -509,6 +509,40 @@ class PostEditor {
     }
   }
 
+  moveSectionBefore(collection, renderedSection, beforeSection) {
+    const newSection = renderedSection.clone();
+    this.removeSection(renderedSection);
+    this.insertSectionBefore(collection, newSection, beforeSection);
+  }
+
+  /**
+   * @method moveSectionUp
+   * @param {Section} section A section that is already in DOM
+   * @public
+   */
+  moveSectionUp(renderedSection) {
+    const isFirst = !renderedSection.prev;
+    if (isFirst) { return; }
+
+    const collection = renderedSection.parent.sections;
+    const beforeSection = renderedSection.prev;
+    this.moveSectionBefore(collection, renderedSection, beforeSection);
+  }
+
+  /**
+   * @method moveSectionDown
+   * @param {Section} section A section that is already in DOM
+   * @public
+   */
+  moveSectionDown(renderedSection) {
+    const isLast = !renderedSection.next;
+    if (isLast) { return; }
+
+    const beforeSection = renderedSection.next.next;
+    const collection = renderedSection.parent.sections;
+    this.moveSectionBefore(collection, renderedSection, beforeSection);
+  }
+
   _replaceSection(section, newSections) {
     let nextSection = section.next;
     let collection = section.parent.sections;

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -16,6 +16,12 @@ export default class Markerable extends Section {
     markers.forEach(m => this.markers.append(m));
   }
 
+  clone() {
+    const newMarkers = this.markers.map(m => m.clone());
+    return this.builder.createMarkerableSection(
+      this.type, this.tagName, newMarkers);
+  }
+
   get isBlank() {
     if (!this.markers.length) {
       return true;

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -41,6 +41,10 @@ export default class Section extends LinkedItem {
     return this._tagName;
   }
 
+  clone() {
+    throw new Error('clone() must be implemented by subclass');
+  }
+
   immediatelyNextMarkerableSection() {
     const next = this.next;
     if (next) {

--- a/src/js/models/card-node.js
+++ b/src/js/models/card-node.js
@@ -35,7 +35,8 @@ export default class CardNode {
         this.display();
       },
       cancel: () => this.display(),
-      remove: () => this.remove()
+      remove: () => this.remove(),
+      section: this.section
     };
   }
 

--- a/src/js/models/card.js
+++ b/src/js/models/card.js
@@ -7,4 +7,8 @@ export default class Card extends Section {
     this.name = name;
     this.payload = payload;
   }
+
+  clone() {
+    return this.builder.createCardSection(this.name, this.payload);
+  }
 }

--- a/src/js/models/post-node-builder.js
+++ b/src/js/models/post-node-builder.js
@@ -9,6 +9,10 @@ import Card from '../models/card';
 import { normalizeTagName } from '../utils/dom-utils';
 import { objectToSortedKVArray } from '../utils/array-utils';
 import {
+  LIST_ITEM_TYPE,
+  MARKUP_SECTION_TYPE
+} from '../models/types';
+import {
   DEFAULT_TAG_NAME as DEFAULT_MARKUP_SECTION_TAG_NAME
 } from '../models/markup-section';
 
@@ -43,8 +47,15 @@ export default class PostNodeBuilder {
     return post;
   }
 
-  createBlankPost() {
-    return this.createPost([this.createMarkupSection()]);
+  createMarkerableSection(type, tagName, markers=[]) {
+    switch (type) {
+      case LIST_ITEM_TYPE:
+        return this.createListItem(tagName, markers);
+      case MARKUP_SECTION_TYPE:
+        return this.createMarkupSection(tagName, markers);
+      default:
+        throw new Error(`Cannot create markerable section of type ${type}`);
+    }
   }
 
   createMarkupSection(tagName=DEFAULT_MARKUP_SECTION_TAG_NAME, markers=[], isGenerated=false) {
@@ -80,7 +91,9 @@ export default class PostNodeBuilder {
   }
 
   createCardSection(name, payload={}) {
-    return new Card(name, payload);
+    const card = new Card(name, payload);
+    card.builder = this;
+    return card;
   }
 
   createMarker(value, markups=[]) {

--- a/src/js/utils/linked-list.js
+++ b/src/js/utils/linked-list.js
@@ -111,6 +111,11 @@ export default class LinkedList {
       item = item.next;
     }
   }
+  map(callback) {
+    let result = [];
+    this.forEach(i => result.push(callback(i)));
+    return result;
+  }
   walk(startItem, endItem, callback) {
     let item = startItem || this.head;
     while (item) {

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -24,8 +24,6 @@ test('sets element as contenteditable', (assert) => {
   assert.equal(editorElement.getAttribute('contenteditable'),
                'true',
                'element is contenteditable');
-  assert.equal(editorElement.firstChild.tagName, 'P',
-               `editor element has a P as its first child`);
 });
 
 test('#disableEditing before render is meaningful', (assert) => {

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -48,6 +48,34 @@ test('rendering a mobiledoc for editing calls card#setup', (assert) => {
   editor.render(editorElement);
 });
 
+test('rendered card env has `name`, `edit`, `save`, `remove`, `section', (assert) => {
+  let cardEnv;
+
+  const cardName = 'test-card';
+  const cards = [{
+    name: cardName,
+    display: {
+      setup(element, options, env) { cardEnv = env; },
+      teardown() {}
+    }
+  }];
+
+  const mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([cardSection('test-card')]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  assert.ok(!!cardEnv, 'card env is present');
+  assert.equal(cardEnv.name, cardName, 'env name is correct');
+  assert.ok(!!cardEnv.edit, 'has edit hook');
+  assert.ok(!!cardEnv.save, 'has save hook');
+  assert.ok(!!cardEnv.cancel, 'has cancel hook');
+  assert.ok(!!cardEnv.remove, 'has remove hook');
+  const cardSection = editor.post.sections.head;
+  assert.ok(cardEnv.section && cardEnv.section === cardSection, 'has `section`');
+});
+
 test('rendering a mobiledoc for editing calls #unknownCardHandler when it encounters an unknown card', (assert) => {
   assert.expect(1);
 

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -3,8 +3,9 @@ import { EDITOR_ELEMENT_CLASS_NAME } from 'content-kit-editor/editor/editor';
 import { normalizeTagName } from 'content-kit-editor/utils/dom-utils';
 import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
 import Range from 'content-kit-editor/utils/cursor/range';
+import Helpers from '../../test-helpers';
 
-const { module, test } = window.QUnit;
+const { module, test } = Helpers;
 
 let fixture, editorElement, editor;
 
@@ -29,10 +30,6 @@ test('can render an editor via dom node reference', (assert) => {
   editor.render(editorElement);
   assert.equal(editor.element, editorElement);
   assert.ok(editor.post);
-  assert.equal(editor.post.sections.length, 1);
-  assert.equal(editor.post.sections.head.tagName, 'p');
-  assert.equal(editor.post.sections.head.markers.length, 0);
-  assert.equal(editor.post.sections.head.text, '');
 });
 
 test('creating an editor with DOM node throws', (assert) => {
@@ -84,7 +81,10 @@ test('editor fires lifecycle hooks', (assert) => {
 
 test('editor fires lifecycle hooks for edit', (assert) => {
   assert.expect(4);
-  editor = new Editor();
+  const mobiledoc = Helpers.mobiledoc.build(({post, markupSection}) => {
+    return post([markupSection()]);
+  });
+  editor = new Editor({mobiledoc});
   editor.render(editorElement);
 
   let didCallUpdatePost, didCallWillRender, didCallDidRender;

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -36,6 +36,7 @@ function renderBuiltAbstract(post) {
   let renderer = new EditorDomRenderer(mockEditor, [], () => {}, {});
   let renderTree = new RenderTree(post);
   renderer.render(renderTree);
+  return mockEditor;
 }
 
 module('Unit: PostEditor with mobiledoc', {
@@ -385,8 +386,9 @@ test('#splitMarkers when headMarker = tailMarker', (assert) => {
     post = buildPost([ section ]);
   });
 
-  renderBuiltAbstract(post);
+  let mockEditor = renderBuiltAbstract(post);
 
+  const postEditor = new PostEditor(mockEditor);
   const range = Range.create(section, 1, section, 3);
   const markers = postEditor.splitMarkers(range);
   postEditor.complete();
@@ -402,10 +404,11 @@ test('#splitMarkers when head section = tail section, but different markers', (a
     ])
   );
 
-  renderBuiltAbstract(post);
+  let mockEditor = renderBuiltAbstract(post);
 
   const section = post.sections.head;
   const range = Range.create(section, 2, section, 5);
+  const postEditor = new PostEditor(mockEditor);
   const markers = postEditor.splitMarkers(range);
   postEditor.complete();
 

--- a/tests/unit/models/post-node-builder-test.js
+++ b/tests/unit/models/post-node-builder-test.js
@@ -41,3 +41,8 @@ test('#createMarkup normalizes tagName', (assert) => {
             m3 === m4, 'all markups are the same');
 });
 
+test('#createCardSection creates card with builder', (assert) => {
+  const builder = new PostNodeBuilder();
+  const cardSection = builder.createCardSection('test-card');
+  assert.ok(cardSection.builder === builder, 'card section has builder');
+});


### PR DESCRIPTION
In order to move a section that is already rendered, we have to remove it
and put a copy of it in the right place. This PR also adds a `clone` method to
sections for that purpose.

This PR removes `builder#createBlankPost`. It previously created a post with
a single empty markup section because posts couldn't have 0 sections, but that
restriction was relaxed recently. Upstream consumers of content-kit were getting
confused by having single empty markup section when booting an editor.

cc @mixonic