### PR TITLE
register arbitrary custom key commands

### DIFF
--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -47,13 +47,20 @@ export const DEFAULT_KEY_COMMANDS = [{
 }];
 
 export function validateKeyCommand(keyCommand) {
-  return !!keyCommand.modifier && !!keyCommand.str && !!keyCommand.run;
+  if (!keyCommand.run) {
+    return false;
+  }
+  return !!keyCommand.check || (!!keyCommand.modifier && !!keyCommand.str);
 }
 
 export function findKeyCommand(keyCommands, keyEvent) {
   const key = Key.fromEvent(keyEvent);
 
-  return detect(keyCommands, ({modifier, str}) => {
-    return key.hasModifier(modifier) && key.isChar(str);
+  return detect(keyCommands, ({modifier, str, check}) => {
+    if (!!check) {
+      return check(keyEvent);
+    } else {
+      return key.hasModifier(modifier) && key.isChar(str);
+    }
   });
 }

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -1,4 +1,5 @@
 import { Editor } from 'content-kit-editor';
+import Keycodes from 'content-kit-editor/utils/keycodes';
 import { MODIFIERS } from 'content-kit-editor/utils/key';
 import Helpers from '../test-helpers';
 
@@ -49,7 +50,7 @@ test('typing command-I italicizes highlighted text', (assert) => {
   assert.hasElement('#editor em:contains(something)', 'text is emphasized');
 });
 
-test('new key commands can be registered', (assert) => {
+test('new simple key commands can be registered', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => post([
       markupSection('p', [marker('something')])
@@ -72,3 +73,27 @@ test('new key commands can be registered', (assert) => {
 
   assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
 });
+
+test('new custom key commands can be registered', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => post([
+      markupSection('p', [marker('something')])
+    ]));
+
+  let passedEditor;
+  editor = new Editor({mobiledoc});
+  editor.registerKeyCommand({
+    check(e) { return e.keyCode === Keycodes.ENTER; },
+    run(editor) { passedEditor = editor; }
+  });
+  editor.render(editorElement);
+
+  Helpers.dom.triggerKeyCommand(editor, 'Y', MODIFIERS.CTRL);
+
+  assert.ok(!passedEditor, 'incorrect key combo does not trigger key command');
+
+  Helpers.dom.triggerEnter(editor);
+
+  assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
+});
+


### PR DESCRIPTION
registerKeyCommand currently requires the string format of the key and a modifier.

This adds the ability to register arbitrary commands by supplying a `check` function 
with the command which is passed the key event.