### PR TITLE
Fix bug when walkMarkerableSections ranges starts with card

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -1,6 +1,7 @@
 import {
   DEFAULT_TAG_NAME as DEFAULT_MARKUP_SECTION_TAG_NAME
 } from '../models/markup-section';
+import { isMarkerable } from '../models/_section';
 import { POST_TYPE, MARKUP_SECTION_TYPE, LIST_ITEM_TYPE } from '../models/types';
 import Position from '../utils/cursor/position';
 import {
@@ -20,10 +21,6 @@ function isListItem(section) {
 
 function isBlankAndListItem(section) {
   return isListItem(section) && section.isBlank;
-}
-
-function isMarkerable(section) {
-  return !!section.markers;
 }
 
 const CALLBACK_QUEUES = {

--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -2,7 +2,7 @@ import { LIST_ITEM_TYPE } from './types';
 import { normalizeTagName } from '../utils/dom-utils';
 import LinkedItem from '../utils/linked-item';
 
-function isMarkerable(section) {
+export function isMarkerable(section) {
   return !!section.markers;
 }
 

--- a/src/js/models/post.js
+++ b/src/js/models/post.js
@@ -2,6 +2,7 @@ import { POST_TYPE } from './types';
 import LinkedList from 'content-kit-editor/utils/linked-list';
 import { forEach, compact } from 'content-kit-editor/utils/array-utils';
 import Set from 'content-kit-editor/utils/set';
+import { isMarkerable } from 'content-kit-editor/models/_section';
 
 export default class Post {
   constructor() {
@@ -102,6 +103,10 @@ export default class Post {
     const {head, tail} = range;
 
     let currentSection = head.section;
+    if (!isMarkerable(currentSection)) {
+      currentSection = this._nextMarkerableSection(currentSection);
+    }
+
     while (currentSection) {
       callback(currentSection);
 
@@ -145,7 +150,6 @@ export default class Post {
   // return the next section that has markers after this one
   _nextMarkerableSection(section) {
     if (!section) { return null; }
-    const isMarkerable = s => !!s.markers;
     const hasChildren  = s => !!s.items;
     const firstChild   = s => s.items.head;
     const isChild      = s => s.parent && !s.post;

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -66,6 +66,22 @@ test('#markersFrom finds markers across non-homogeneous sections', (assert) => {
                    'iterates correct markers');
 });
 
+test('#walkMarkerableSections finds no section when range contains only a card', (assert) => {
+  const post = Helpers.postAbstract.build(builder => {
+    const {post, cardSection} = builder;
+
+    return post([cardSection('simple-card')]);
+  });
+
+  let foundSections = [];
+
+  const card = post.sections.objectAt(0);
+  const range = Range.create(card, 0, card, 0);
+
+  post.walkMarkerableSections(range, s => foundSections.push(s));
+  assert.equal(foundSections.length, 0, 'found no markerable sections');
+});
+
 test('#walkMarkerableSections skips non-markerable sections', (assert) => {
   const post = Helpers.postAbstract.build(builder => {
     const {post, markupSection, marker, cardSection} = builder;


### PR DESCRIPTION
`post#walkMarkerableSections` used to always call the callback for the head section in the range. Now it checks to make sure that is a markerable section.