### PR TITLE
Key commands refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ For more details on the API of `postEditor`, see the [API documentation](https:/
 For more details on the API for the builder, required to create new sections
 and markers, see the [builder API](https://github.com/bustlelabs/content-kit-editor/blob/master/src/js/models/post-node-builder.js).
 
-### Configuring hot keys and text expansions
+### Configuring hot keys
 
 Content-Kit allows configuring hot keys and text expansions. For instance, the
 hot-key command-B to make selected text bold, is registered internally as:
+
 ```javascript
 const boldKeyCommand = {
-  modifier: META,
-  str: 'B',
+  str: 'META+B',
   run(editor) {
     editor.run(postEditor => postEditor.toggleMarkup('strong'));
   }
@@ -139,7 +139,48 @@ const boldKeyCommand = {
 editor.registerKeyCommand(boldKeyCommand);
 ```
 
-All key commands must have `modifier`, `str` and `run` properties as shown above.
+All key commands must have `str` and `run` properties as shown above.
+
+`str` describes the key combination to use and may be a single key, or a modifier and a key separated by `+`.
+
+Modifiers can be one of `CTRL`, `META` or `SHIFT`.
+
+The key can be any of the alphanumeric characters on the keyboard, or one of the following special keys:
+
+* `BACKSPACE`
+* `TAB`
+* `ENTER`
+* `ESC`
+* `SPACE`
+* `PAGEUP`
+* `PAGEDOWN`
+* `END`
+* `HOME`
+* `LEFT`
+* `UP`
+* `RIGHT`
+* `DOWN`
+* `INS`
+* `DEL`
+
+#### Overriding built-in keys
+
+You can override built-in behavior by simply registering a hot key with the same name.
+For example, to submit a form instead of entering a new line when `enter` is pressed you could do the following:
+
+```javascript
+const enterKeyCommand = {
+  str: 'enter',
+  run(editor) {
+    // submit the form
+  }
+};
+editor.registerKeyCommand(enterKeyCommand);
+```
+
+To fall-back to the default behavior, simply return `false` from `run`.
+
+### Configuring text expansions
 
 Text expansions can also be registered with the editor. These are methods that
 are run when a text string is entered and then a trigger character is entered.

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -584,6 +584,10 @@ class Editor {
       this._insertEmptyMarkupSectionAtCursor();
     }
 
+    if (this.handleKeyCommand(event)) {
+      return;
+    }
+
     const key = Key.fromEvent(event);
 
     if (key.isDelete()) {
@@ -600,7 +604,6 @@ class Editor {
     }
 
     this.handleExpansion(event);
-    this.handleKeyCommand(event);
   }
 
   /**
@@ -614,6 +617,7 @@ class Editor {
    *
    * @method handleKeyCommand
    * @param {Event} event The keyboard event triggered by the user
+   * @return {Boolean} true when a command was successfully run
    * @private
    */
   handleKeyCommand(event) {
@@ -622,9 +626,10 @@ class Editor {
       let keyCommand = keyCommands[i];
       if (keyCommand.run(this) !== false) {
         event.preventDefault();
-        return;
+        return true;
       }
     }
+    return false;
   }
 
   handlePaste(event) {

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -26,7 +26,7 @@ import {
   DEFAULT_TEXT_EXPANSIONS, findExpansion, validateExpansion
 } from './text-expansions';
 import {
-  DEFAULT_KEY_COMMANDS, findKeyCommands, validateKeyCommand
+  DEFAULT_KEY_COMMANDS, buildKeyCommand, findKeyCommands, validateKeyCommand
 } from './key-commands';
 import { capitalize } from '../utils/string-utils';
 import LifecycleCallbacksMixin from '../utils/lifecycle-callbacks';
@@ -192,7 +192,8 @@ class Editor {
    * is invoked
    * @public
    */
-  registerKeyCommand(keyCommand) {
+  registerKeyCommand(rawKeyCommand) {
+    const keyCommand = buildKeyCommand(rawKeyCommand);
     if (!validateKeyCommand(keyCommand)) {
       throw new Error('Key Command is not valid');
     }

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -26,7 +26,7 @@ import {
   DEFAULT_TEXT_EXPANSIONS, findExpansion, validateExpansion
 } from './text-expansions';
 import {
-  DEFAULT_KEY_COMMANDS, findKeyCommand, validateKeyCommand
+  DEFAULT_KEY_COMMANDS, findKeyCommands, validateKeyCommand
 } from './key-commands';
 import { capitalize } from '../utils/string-utils';
 import LifecycleCallbacksMixin from '../utils/lifecycle-callbacks';
@@ -196,7 +196,7 @@ class Editor {
     if (!validateKeyCommand(keyCommand)) {
       throw new Error('Key Command is not valid');
     }
-    this.keyCommands.push(keyCommand);
+    this.keyCommands.unshift(keyCommand);
   }
 
   handleExpansion(event) {
@@ -602,11 +602,27 @@ class Editor {
     this.handleKeyCommand(event);
   }
 
+  /**
+   * Finds and runs the first matching key command for the event
+   *
+   * If multiple commands are bound to a key combination, the
+   * first matching one is run.
+   *
+   * If a command returns `false` then the next matching command
+   * is run instead.
+   *
+   * @method handleKeyCommand
+   * @param {Event} event The keyboard event triggered by the user
+   * @private
+   */
   handleKeyCommand(event) {
-    const keyCommand = findKeyCommand(this.keyCommands, event);
-    if (keyCommand) {
-      event.preventDefault();
-      keyCommand.run(this);
+    const keyCommands = findKeyCommands(this.keyCommands, event);
+    for (let i=0; i<keyCommands.length; i++) {
+      let keyCommand = keyCommands[i];
+      if (keyCommand.run(this) !== false) {
+        event.preventDefault();
+        return;
+      }
     }
   }
 

--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -1,6 +1,6 @@
 import Key from '../utils/key';
 import { MODIFIERS } from '../utils/key';
-import { detect } from '../utils/array-utils';
+import { filter } from '../utils/array-utils';
 import LinkCommand from '../commands/link';
 
 export const DEFAULT_KEY_COMMANDS = [{
@@ -50,10 +50,10 @@ export function validateKeyCommand(keyCommand) {
   return !!keyCommand.modifier && !!keyCommand.str && !!keyCommand.run;
 }
 
-export function findKeyCommand(keyCommands, keyEvent) {
+export function findKeyCommands(keyCommands, keyEvent) {
   const key = Key.fromEvent(keyEvent);
 
-  return detect(keyCommands, ({modifier, str}) => {
+  return filter(keyCommands, ({modifier, str}) => {
     return key.hasModifier(modifier) && key.isChar(str);
   });
 }

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -1,13 +1,31 @@
 import Keycodes from './keycodes';
 export const DIRECTION = {
   FORWARD: 1,
-  BACKWARD: -1 
+  BACKWARD: -1
 };
 
 export const MODIFIERS = {
   META: 1, // also called "command" on OS X
   CTRL: 2,
   SHIFT: 3
+};
+
+export const SPECIAL_KEYS = {
+  BACKSPACE: 8,
+  TAB:       9,
+  ENTER:     13,
+  ESC:       27,
+  SPACE:     32,
+  PAGEUP:    33,
+  PAGEDOWN:  34,
+  END:       35,
+  HOME:      36,
+  LEFT:      37,
+  UP:        38,
+  RIGHT:     39,
+  DOWN:      40,
+  INS:       45,
+  DEL:       46
 };
 
 /**
@@ -65,6 +83,10 @@ const Key = class Key {
       default:
         throw new Error(`Cannot check for unknown modifier ${modifier}`);
     }
+  }
+
+  hasAnyModifier() {
+    return this.metaKey || this.ctrlKey || this.shiftKey;
   }
 
   get ctrlKey() {

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -69,7 +69,7 @@ const Key = class Key {
   }
 
   isShift() {
-    return this.hasModifier(MODIFIERS.SHIFT);
+    return this.shiftKey;
   }
 
   hasModifier(modifier) {
@@ -95,6 +95,10 @@ const Key = class Key {
 
   get metaKey() {
     return this.event.metaKey;
+  }
+
+  get shiftKey() {
+    return this.event.shiftKey;
   }
 
   isChar(string) {

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -58,8 +58,7 @@ test('new key commands can be registered', (assert) => {
   let passedEditor;
   editor = new Editor({mobiledoc});
   editor.registerKeyCommand({
-    modifier: MODIFIERS.CTRL,
-    str: 'X',
+    str: 'ctrl+x',
     run(editor) { passedEditor = editor; }
   });
   editor.render(editorElement);
@@ -73,6 +72,33 @@ test('new key commands can be registered', (assert) => {
   assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
 });
 
+test('new key commands can be registered without modifiers', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => post([
+      markupSection('p', [marker('something')])
+    ]));
+
+  let passedEditor;
+  editor = new Editor({mobiledoc});
+  editor.registerKeyCommand({
+    str: 'X',
+    run(editor) { passedEditor = editor; }
+  });
+  editor.render(editorElement);
+
+  Helpers.dom.triggerKeyCommand(editor, 'Y', MODIFIERS.CTRL);
+
+  assert.ok(!passedEditor, 'incorrect key combo does not trigger key command');
+
+  Helpers.dom.triggerKeyCommand(editor, 'X', MODIFIERS.CTRL);
+
+  assert.ok(!passedEditor, 'key with modifier combo does not trigger key command');
+
+  Helpers.dom.triggerKeyCommand(editor, 'X');
+
+  assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
+});
+
 test('duplicate key commands can be registered with the last registered winning', (assert) => {
   const mobiledoc = Helpers.mobiledoc.build(
     ({post, markupSection, marker}) => post([
@@ -82,13 +108,11 @@ test('duplicate key commands can be registered with the last registered winning'
   let firstCommandRan, secondCommandRan;
   editor = new Editor({mobiledoc});
   editor.registerKeyCommand({
-    modifier: MODIFIERS.CTRL,
-    str: 'X',
+    str: 'ctrl+x',
     run() { firstCommandRan = true; }
   });
   editor.registerKeyCommand({
-    modifier: MODIFIERS.CTRL,
-    str: 'X',
+    str: 'ctrl+x',
     run() { secondCommandRan = true; }
   });
   editor.render(editorElement);
@@ -108,13 +132,11 @@ test('returning false from key command causes next match to run', (assert) => {
   let firstCommandRan, secondCommandRan;
   editor = new Editor({mobiledoc});
   editor.registerKeyCommand({
-    modifier: MODIFIERS.CTRL,
-    str: 'X',
+    str: 'ctrl+x',
     run() { firstCommandRan = true; }
   });
   editor.registerKeyCommand({
-    modifier: MODIFIERS.CTRL,
-    str: 'X',
+    str: 'ctrl+x',
     run() {
       secondCommandRan = true;
       return false;

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -72,3 +72,59 @@ test('new key commands can be registered', (assert) => {
 
   assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
 });
+
+test('duplicate key commands can be registered with the last registered winning', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => post([
+      markupSection('p', [marker('something')])
+    ]));
+
+  let firstCommandRan, secondCommandRan;
+  editor = new Editor({mobiledoc});
+  editor.registerKeyCommand({
+    modifier: MODIFIERS.CTRL,
+    str: 'X',
+    run() { firstCommandRan = true; }
+  });
+  editor.registerKeyCommand({
+    modifier: MODIFIERS.CTRL,
+    str: 'X',
+    run() { secondCommandRan = true; }
+  });
+  editor.render(editorElement);
+
+  Helpers.dom.triggerKeyCommand(editor, 'X', MODIFIERS.CTRL);
+
+  assert.ok(!firstCommandRan, 'first registered method not called');
+  assert.ok(!!secondCommandRan, 'last registered method is called');
+});
+
+test('returning false from key command causes next match to run', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => post([
+      markupSection('p', [marker('something')])
+    ]));
+
+  let firstCommandRan, secondCommandRan;
+  editor = new Editor({mobiledoc});
+  editor.registerKeyCommand({
+    modifier: MODIFIERS.CTRL,
+    str: 'X',
+    run() { firstCommandRan = true; }
+  });
+  editor.registerKeyCommand({
+    modifier: MODIFIERS.CTRL,
+    str: 'X',
+    run() {
+      secondCommandRan = true;
+      return false;
+    }
+  });
+  editor.render(editorElement);
+
+  Helpers.dom.triggerKeyCommand(editor, 'X', MODIFIERS.CTRL);
+
+  assert.ok(!!secondCommandRan, 'last registered method is called');
+  assert.ok(!!firstCommandRan, 'first registered method is called');
+});
+

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -150,3 +150,56 @@ test('returning false from key command causes next match to run', (assert) => {
   assert.ok(!!firstCommandRan, 'first registered method is called');
 });
 
+test('key commands can override built-in functionality', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => post([
+      markupSection('p', [marker('something')])
+    ]));
+
+  editor = new Editor({mobiledoc});
+
+  let passedEditor;
+  editor.registerKeyCommand({
+    str: 'enter',
+    run(editor) { passedEditor = editor; }
+  });
+
+  editor.render(editorElement);
+  assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
+
+  Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 5);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
+
+  assert.equal($('#editor p').length, 1, 'still has just one paragraph');
+});
+
+test('returning false from key command still runs built-in functionality', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(
+    ({post, markupSection, marker}) => post([
+      markupSection('p', [marker('something')])
+    ]));
+
+  editor = new Editor({mobiledoc});
+
+  let passedEditor;
+  editor.registerKeyCommand({
+    str: 'enter',
+    run(editor) {
+      passedEditor = editor;
+      return false;
+    }
+  });
+
+  editor.render(editorElement);
+  assert.equal($('#editor p').length, 1, 'has 1 paragraph to start');
+
+  Helpers.dom.moveCursorTo(editorElement.childNodes[0].childNodes[0], 5);
+  Helpers.dom.triggerEnter(editor);
+
+  assert.ok(!!passedEditor && passedEditor === editor, 'run method is called');
+
+  assert.equal($('#editor p').length, 2, 'has added a new paragraph');
+});
+

--- a/tests/unit/editor/key-commands-test.js
+++ b/tests/unit/editor/key-commands-test.js
@@ -1,0 +1,72 @@
+import { buildKeyCommand } from 'content-kit-editor/editor/key-commands';
+import { MODIFIERS, SPECIAL_KEYS } from 'content-kit-editor/utils/key';
+import Keycodes from 'content-kit-editor/utils/keycodes';
+
+import Helpers from '../../test-helpers';
+
+const { module, test } = Helpers;
+
+module('Unit: Editor key commands');
+
+test('leaves modifier, code and run in place if they exist', (assert) => {
+  const fn = function() {};
+
+  const {
+    modifier, code, run
+  } = buildKeyCommand({
+    code: Keycodes.ENTER,
+    modifier: MODIFIERS.META,
+    run: fn
+  });
+
+  assert.equal(modifier, MODIFIERS.META, 'keeps modifier');
+  assert.equal(code, Keycodes.ENTER, 'keeps code');
+  assert.equal(run, fn, 'keeps run');
+});
+
+test('translates MODIFIER+CHARACTER string to modifier and code', (assert) => {
+
+  const { modifier, code } = buildKeyCommand({ str: 'meta+k' });
+
+  assert.equal(modifier, MODIFIERS.META, 'translates string to modifier');
+  assert.equal(code, 75, 'translates string to code');
+});
+
+test('translates modifier+character string to modifier and code', (assert) => {
+
+  const { modifier, code } = buildKeyCommand({ str: 'META+K' });
+
+  assert.equal(modifier, MODIFIERS.META, 'translates string to modifier');
+  assert.equal(code, 75, 'translates string to code');
+});
+
+test('translates uppercase character string to code', (assert) => {
+
+  const { modifier, code } = buildKeyCommand({ str: 'K' });
+
+  assert.equal(modifier, undefined, 'no modifier given');
+  assert.equal(code, 75, 'translates string to code');
+});
+
+test('translates lowercase character string to code', (assert) => {
+
+  const { modifier, code } = buildKeyCommand({ str: 'k' });
+
+  assert.equal(modifier, undefined, 'no modifier given');
+  assert.equal(code, 75, 'translates string to code');
+
+});
+
+test('translates uppercase special key names to codes', (assert) => {
+  Object.keys(SPECIAL_KEYS).forEach(name => {
+    const { code } = buildKeyCommand({ str: name.toUpperCase() });
+    assert.equal(code, SPECIAL_KEYS[name], `translates ${name} string to code`);
+  });
+});
+
+test('translates lowercase special key names to codes', (assert) => {
+  Object.keys(SPECIAL_KEYS).forEach(name => {
+    const { code } = buildKeyCommand({ str: name.toLowerCase() });
+    assert.equal(code, SPECIAL_KEYS[name], `translates ${name} string to code`);
+  });
+});

--- a/tests/unit/utils/key-test.js
+++ b/tests/unit/utils/key-test.js
@@ -1,0 +1,39 @@
+import Helpers from '../../test-helpers';
+import Key from 'content-kit-editor/utils/key';
+import { MODIFIERS } from 'content-kit-editor/utils/key';
+
+const {module, test} = Helpers;
+
+module('Unit: Utils: Key');
+
+test('#hasModifier with no modifier', (assert) => {
+  const key = Key.fromEvent({ keyCode: 42 });
+
+  assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
+  assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");
+  assert.ok(!key.hasModifier(MODIFIERS.SHIFT), "SHIFT not pressed");
+});
+
+test('#hasModifier with META', (assert) => {
+  const key = Key.fromEvent({ metaKey: true });
+
+  assert.ok(key.hasModifier(MODIFIERS.META), "META pressed");
+  assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");
+  assert.ok(!key.hasModifier(MODIFIERS.SHIFT), "SHIFT not pressed");
+});
+
+test('#hasModifier with CTRL', (assert) => {
+  const key = Key.fromEvent({ ctrlKey: true });
+
+  assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
+  assert.ok(key.hasModifier(MODIFIERS.CTRL), "CTRL pressed");
+  assert.ok(!key.hasModifier(MODIFIERS.SHIFT), "SHIFT not pressed");
+});
+
+test('#hasModifier with SHIFT', (assert) => {
+  const key = Key.fromEvent({ shiftKey: true });
+
+  assert.ok(!key.hasModifier(MODIFIERS.META), "META not pressed");
+  assert.ok(!key.hasModifier(MODIFIERS.CTRL), "CTRL not pressed");
+  assert.ok(key.hasModifier(MODIFIERS.SHIFT), "SHIFT pressed");
+});


### PR DESCRIPTION
This refactors key commands so that:

* special keys can be registered ("enter", "tab", "backspace" etc…)
* combo strings can be registered ("CMD+C" vs separate modifier)
* duplicate keys can be registered and fall back if they return `false` from `run`
* built-in commands can be overridden (eg register "enter" to override new-line behaviour)

This removes the requirement that all registered keys have a modifier, so that you can register just "tab" etc… we may want to only allow this for "special" keys so you still have to have a modifier for regular characters?

Registering a combo string simply transforms it to a modifier (if present) and code combination, so is completely backwards compatible.

This doesn't add any support for multiple modifiers ("CTRL+CMD+X"), or for sequences ("up up down down left right left right B A").

Closes #168 