### PR TITLE
Allow silent payload saving

### DIFF
--- a/CARDS.md
+++ b/CARDS.md
@@ -68,8 +68,10 @@ var exampleCard = {
 * `env` contains information about the running of this hook. It may contain
   the following properties:
   * `env.name` The name of this card
-  * `env.save(payload)` will save a new payload for a card instance, then
-    swap a card in edit mode to display.
+  * `env.save(payload)` will save a new payload for a card instance. `save`
+    also accepts a boolean as a second argument, `true` if the card should
+    be transitioned to `display` and `false` if it should remain in `edit`
+    mode. The default behavior is to transition to `display`.
   * `env.cancel()` will swap a card in edit mode to display without changing
     the payload.
   * `env.edit()` is available to the `display` setup, and when called swaps

--- a/src/js/models/card-node.js
+++ b/src/js/models/card-node.js
@@ -28,11 +28,13 @@ export default class CardNode {
     return {
       name: this.card.name,
       edit: () => this.edit(),
-      save: (payload) => {
+      save: (payload, transition=true) => {
         this.section.payload = payload;
 
         this.editor.didUpdate();
-        this.display();
+        if (transition) {
+          this.display();
+        }
       },
       cancel: () => this.display(),
       remove: () => this.remove(),

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -178,6 +178,42 @@ test('rendered card can fire edit hook to enter editing mode, then save', (asser
   assert.equal(secondPayload, newPayload, 'second display with new payload');
 });
 
+test('rendered card can fire edit hook to enter editing mode, then silently save', (assert) => {
+  const setupPayloads = [];
+  const payload = { foo: 'bar' };
+  const newPayload = {some: 'new values'};
+  let cardEnv;
+
+  const card = {
+    name: 'test-card',
+    display: {
+      setup() {
+        assert.ok(false, 'card should never be displayed in this test');
+      }
+    },
+    edit: {
+      setup(element, options, env, setupPayload) {
+        cardEnv = env;
+        setupPayloads.push(setupPayload);
+      }
+    }
+  };
+
+  const mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) =>
+    post([ cardSection('test-card', payload) ])
+  );
+  editor = new Editor({ mobiledoc, cards: [card] });
+  editor.editCard(editor.post.sections.head);
+  editor.render(editorElement);
+
+  cardEnv.save(newPayload, false);
+
+  const [firstPayload] = setupPayloads;
+  assert.equal(firstPayload, payload, 'first display with mobiledoc payload');
+  let secondPayload = editor.post.sections.head.payload;
+  assert.equal(secondPayload, newPayload, 'second display with new payload');
+});
+
 test('rendered card can fire edit hook to enter editing mode, then cancel', (assert) => {
   const setupPayloads = [];
   let cardEnv;


### PR DESCRIPTION
`env.save(newPayload, false)` on a card env will save the payload without transitioning the card to `display`.