### PR TITLE
Remove dragover, drop listeners

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -523,7 +523,7 @@ class Editor {
   }
 
   _setupListeners() {
-    const elementEvents = ['keydown', 'keyup', 'input', 'dragover', 'drop', 'paste'];
+    const elementEvents = ['keydown', 'keyup', 'input', 'paste'];
     const documentEvents = ['mouseup'];
 
     elementEvents.forEach(eventName => {
@@ -584,14 +584,6 @@ class Editor {
         this._hasSelection = false;
       }
     }
-  }
-
-  handleDragover(e) {
-    e.preventDefault(); // FIXME for now, just prevent default
-  }
-
-  handleDrop(e) {
-    e.preventDefault(); // FIXME for now, just prevent default
   }
 
   _insertEmptyMarkupSectionAtCursor() {


### PR DESCRIPTION
Catching and canceling these events prevents any other party from
reacting to drag/drop events in a card.