### PR TITLE
execCommands for bold, italic without selection

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -305,13 +305,6 @@ class Editor {
   }
 
   reparse() {
-    let { headSection, headSectionOffset } = this.cursor.offsets;
-    if (headSectionOffset === 0) {
-      // FIXME if the offset is 0, the user is typing the first character
-      // in an empty section, so we need to move the cursor 1 letter forward
-      headSectionOffset = 1;
-    }
-
     this._reparseCurrentSection();
     this._removeDetachedSections();
 
@@ -320,8 +313,6 @@ class Editor {
     this.run(() => {});
     this.rerender();
     this.trigger('update');
-
-    this.cursor.moveToSection(headSection, headSectionOffset);
   }
 
   // FIXME this should be able to be removed now -- if any sections are detached,
@@ -595,13 +586,12 @@ class Editor {
   }
 
   handleKeydown(event) {
-    if (!this.isEditable) { return; }
-    if (this.post.isBlank) {
-      this._insertEmptyMarkupSectionAtCursor();
+    if (!this.isEditable || this.handleKeyCommand(event)) {
+      return;
     }
 
-    if (this.handleKeyCommand(event)) {
-      return;
+    if (this.post.isBlank) {
+      this._insertEmptyMarkupSectionAtCursor();
     }
 
     const key = Key.fromEvent(event);

--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -2,36 +2,66 @@ import Key from '../utils/key';
 import { MODIFIERS, SPECIAL_KEYS } from '../utils/key';
 import { filter } from '../utils/array-utils';
 import LinkCommand from '../commands/link';
+import Position from '../utils/cursor/position';
 
 export const DEFAULT_KEY_COMMANDS = [{
   modifier: MODIFIERS.META,
   str: 'B',
   run(editor) {
-    editor.run(postEditor => postEditor.toggleMarkup('strong'));
+    if (editor.cursor.hasSelection()) {
+      editor.run(postEditor => postEditor.toggleMarkup('strong'));
+    } else {
+      document.execCommand('bold', false, null);
+    }
   }
 }, {
   modifier: MODIFIERS.CTRL,
   str: 'B',
   run(editor) {
-    editor.run(postEditor => postEditor.toggleMarkup('strong'));
+    if (editor.cursor.hasSelection()) {
+      editor.run(postEditor => postEditor.toggleMarkup('strong'));
+    } else {
+      document.execCommand('bold', false, null);
+    }
   }
 }, {
   modifier: MODIFIERS.META,
   str: 'I',
   run(editor) {
-    editor.run(postEditor => postEditor.toggleMarkup('em'));
+    if (editor.cursor.hasSelection()) {
+      editor.run(postEditor => postEditor.toggleMarkup('em'));
+    } else {
+      document.execCommand('italic', false, null);
+    }
   }
 }, {
   modifier: MODIFIERS.CTRL,
   str: 'I',
   run(editor) {
-    editor.run(postEditor => postEditor.toggleMarkup('em'));
+    if (editor.cursor.hasSelection()) {
+      editor.run(postEditor => postEditor.toggleMarkup('em'));
+    } else {
+      document.execCommand('italic', false, null);
+    }
+  }
+}, {
+  modifier: MODIFIERS.CTRL,
+  str: 'K',
+  run(editor) {
+    let range = editor.cursor.offsets;
+    if (!editor.cursor.hasSelection()) {
+      range.tail = new Position(range.head.section, range.head.section.length);
+    }
+    editor.run(postEditor => postEditor.deleteRange(range));
+    editor.cursor.moveToPosition(range.head);
   }
 }, {
   modifier: MODIFIERS.META,
   str: 'K',
   run(editor) {
-    if (!editor.cursor.hasSelection()) { return; }
+    if (!editor.cursor.hasSelection()) {
+      return;
+    }
 
     let selectedText = editor.cursor.selectedText();
     let defaultUrl = '';

--- a/src/js/parsers/post.js
+++ b/src/js/parsers/post.js
@@ -9,6 +9,17 @@ import { forEach } from 'content-kit-editor/utils/array-utils';
 import { getAttributes, walkTextNodes } from '../utils/dom-utils';
 import Markup from 'content-kit-editor/models/markup';
 
+const TAG_REMAPPING = {
+  'b': 'strong',
+  'i': 'em'
+};
+
+function normalizeTagName(tagName) {
+  let normalized = tagName.toLowerCase();
+  let remapped = TAG_REMAPPING[normalized];
+  return remapped || normalized;
+}
+
 export default class PostParser {
   constructor(builder) {
     this.builder = builder;
@@ -53,7 +64,7 @@ export default class PostParser {
     if (Markup.isValidElement(node)) {
       const tagName = node.tagName;
       const attributes = getAttributes(node);
-      return this.builder.createMarkup(tagName, attributes);
+      return this.builder.createMarkup(normalizeTagName(tagName), attributes);
     }
   }
 

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -88,14 +88,16 @@ const mobileDocWithNoCharacter = {
 
 module('Acceptance: Editor sections', {
   beforeEach() {
-    fixture = document.getElementById('qunit-fixture');
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    fixture.appendChild(editorElement);
+    fixture = $('#qunit-fixture');
+    editorElement = $('<div id="editor"></div>')[0];
+    fixture.append(editorElement);
   },
 
   afterEach() {
-    if (editor) { editor.destroy(); }
+    if (editor) {
+      editor.destroy();
+      editor = null;
+    }
   }
 });
 
@@ -405,14 +407,14 @@ test('when selection incorrectly contains P end tag, editor reports correct sele
       headSectionOffset, tailSectionOffset, headMarkerOffset, tailMarkerOffset
     } = editor.cursor.offsets;
 
-    assert.equal(headSection, editor.post.sections.objectAt(0),
-                 'returns first section head');
-    assert.equal(tailSection, editor.post.sections.objectAt(1),
-                 'returns second section tail');
-    assert.equal(headMarker, editor.post.sections.objectAt(0).markers.head,
-                 'returns first section marker head');
-    assert.equal(tailMarker, editor.post.sections.objectAt(1).markers.head,
-                 'returns second section marker tail');
+    assert.ok(headSection === editor.post.sections.objectAt(0),
+              'returns first section head');
+    assert.ok(tailSection === editor.post.sections.objectAt(1),
+              'returns second section tail');
+    assert.ok(headMarker === editor.post.sections.objectAt(0).markers.head,
+              'returns first section marker head');
+    assert.ok(tailMarker === editor.post.sections.objectAt(1).markers.head,
+              'returns second section marker tail');
     assert.equal(headMarkerOffset, 0, 'headMarkerOffset correct');
     assert.equal(tailMarkerOffset, 0, 'tailMarkerOffset correct');
     assert.equal(headSectionOffset, 0, 'headSectionOffset correct');


### PR DESCRIPTION
Currently, Content-Kit still parses the DOM after each keystroke. We are pretty good at it (text and DOM nodes from parsed section are re-used instead of being rerendered) however it does mean we cannot easily create our own stateful markup system for bold and italic. Specifically, for when bold or italic are toggled without a selection.

This patch restores a native behavior for contentEditables: Toggling italic or bold without a selection will just call the proper execCommand. This then applied to the next input.

The compromise is that execCommands vary from implementation to implementation, for example on Chrome they output a `b` tag, however on IE a `strong` tag is generated. See the following link for more details:

http://help.dottoro.com/ljcvtcaw.php

Here we normalize the `b` tag during section parse (there are two DOM parsers, this is the "safe" DOM one) into a `strong` markup. This means buttons toggling `strong` continue to work and the `b` tag is not
persisted into the mobiledoc. However, the `b` tag stays in DOM.

Additionally:

* Cleans up setup/teardown for some tests
* Use `ok` and equality checks to avoid QUnits terrible diffing system for   displayed failures of `equal`
* During reparse, we were resetting the cursor position. This was related to ctrl-k on OSX, which clears to the end of the line. Here that functionality is re-implemented as a key command. https://github.com/bustlelabs/content-kit-editor/issues/96

![](http://g.recordit.co/sJxzFg900z.gif)