### PR TITLE
Parse ul and ols correctly

### DIFF
--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -1,5 +1,12 @@
 import Markerable from './_markerable';
 import { LIST_ITEM_TYPE } from './types';
+import {
+  normalizeTagName
+} from 'content-kit-editor/utils/dom-utils';
+
+export const VALID_LIST_ITEM_TAGNAMES = [
+  'li'
+].map(normalizeTagName);
 
 export default class ListItem extends Markerable {
   constructor(tagName, markers=[]) {

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -2,8 +2,15 @@ import LinkedList from '../utils/linked-list';
 import { forEach } from '../utils/array-utils';
 import { LIST_SECTION_TYPE } from './types';
 import Section from './_section';
+import {
+  normalizeTagName
+} from 'content-kit-editor/utils/dom-utils';
 
-export const DEFAULT_TAG_NAME = 'ul';
+export const VALID_LIST_SECTION_TAGNAMES = [
+  'ul', 'ol'
+].map(normalizeTagName);
+
+export const DEFAULT_TAG_NAME = VALID_LIST_SECTION_TAGNAMES[0];
 
 export default class ListSection extends Section {
   constructor(tagName=DEFAULT_TAG_NAME, items=[]) {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -4,14 +4,14 @@ import { MARKUP_SECTION_TYPE } from './types';
 
 // valid values of `tagName` for a MarkupSection
 export const VALID_MARKUP_SECTION_TAGNAMES = [
-  'p', 'h3', 'h2', 'h1', 'blockquote', 'ul', 'ol', 'pull-quote'
+  'p', 'h3', 'h2', 'h1', 'blockquote', 'pull-quote'
 ].map(normalizeTagName);
 
 // valid element names for a MarkupSection. A MarkupSection with a tagName
-// not in this should be rendered as a div with a className matching the
-// tagName, instead
+// not in this will be rendered as a div with a className matching the
+// tagName
 export const MARKUP_SECTION_ELEMENT_NAMES = [
-  'p', 'h3', 'h2', 'h1', 'blockquote', 'ul', 'ol'
+  'p', 'h3', 'h2', 'h1', 'blockquote'
 ].map(normalizeTagName);
 export const DEFAULT_TAG_NAME = VALID_MARKUP_SECTION_TAGNAMES[0];
 

--- a/src/js/models/markup.js
+++ b/src/js/models/markup.js
@@ -8,8 +8,7 @@ export const VALID_MARKUP_TAGNAMES = [
   'i',
   'strong',
   'em',
-  'a',
-  'li'
+  'a'
 ].map(normalizeTagName);
 
 export const VALID_ATTRIBUTES = [

--- a/src/js/utils/array-utils.js
+++ b/src/js/utils/array-utils.js
@@ -130,6 +130,10 @@ function filterObject(object, validKeys=[]) {
   return result;
 }
 
+function contains(array, item) {
+  return array.indexOf(item) !== -1;
+}
+
 export {
   detect,
   forEach,
@@ -143,5 +147,6 @@ export {
   kvArrayToObject,
   isArrayEqual,
   toArray,
-  filterObject
+  filterObject,
+  contains
 };

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -323,4 +323,67 @@ test('unrecognized attributes are ignored', (assert) => {
   assert.ok(!markup.getAttribute('style'), 'style attribute not included');
 });
 
-// FIXME TODO ul, ol, li, img parsing
+test('singly-nested ul lis are parsed correctly', (assert) => {
+  let element= buildDOM(`
+    <ul><li>first element</li><li>second element</li></ul>
+  `);
+  const post = parser.parse(element);
+
+  assert.equal(post.sections.length, 1, '1 section');
+  let section = post.sections.objectAt(0);
+  assert.equal(section.tagName, 'ul');
+  assert.equal(section.items.length, 2, '2 items');
+  assert.equal(section.items.objectAt(0).text, 'first element');
+  assert.equal(section.items.objectAt(1).text, 'second element');
+});
+
+test('singly-nested ol lis are parsed correctly', (assert) => {
+  let element= buildDOM(`
+    <ol><li>first element</li><li>second element</li></ol>
+  `);
+  const post = parser.parse(element);
+
+  assert.equal(post.sections.length, 1, '1 section');
+  let section = post.sections.objectAt(0);
+  assert.equal(section.tagName, 'ol');
+  assert.equal(section.items.length, 2, '2 items');
+  assert.equal(section.items.objectAt(0).text, 'first element');
+  assert.equal(section.items.objectAt(1).text, 'second element');
+});
+
+test('lis in nested uls are flattened (when ul is child of li)', (assert) => {
+  let element= buildDOM(`
+    <ul>
+      <li>first element</li>
+      <li><ul><li>nested element</li></ul></li>
+    </ul>
+  `);
+  const post = parser.parse(element);
+
+  assert.equal(post.sections.length, 1, '1 section');
+  let section = post.sections.objectAt(0);
+  assert.equal(section.tagName, 'ul');
+  assert.equal(section.items.length, 2, '2 items');
+  assert.equal(section.items.objectAt(0).text, 'first element');
+  assert.equal(section.items.objectAt(1).text, 'nested element');
+});
+
+/*
+ * FIXME: Google docs nests uls like this
+test('lis in nested uls are flattened (when ul is child of ul)', (assert) => {
+  let element= buildDOM(`
+    <ul>
+      <li>outer</li>
+      <ul><li>inner</li></ul>
+    </ul>
+  `);
+  const post = parser.parse(element);
+
+  assert.equal(post.sections.length, 1, '1 section');
+  let section = post.sections.objectAt(0);
+  assert.equal(section.tagName, 'ul');
+  assert.equal(section.items.length, 2, '2 items');
+  assert.equal(section.items.objectAt(0).text, 'outer');
+  assert.equal(section.items.objectAt(1).text, 'inner');
+});
+ */


### PR DESCRIPTION
This adds code to parse DOM with ul and ol correctly. Prior to this, markups with tagName "li" were incorrectly generated sometimes, and it was possible to create a corrupt mobiledoc by pasting in a list.

fixes #183

The parsing is fairly naive, and doesn't handle all types of nested lists. On those that it can't handle it just ignores the parsed sections rather than inserting invalid stuff into the mobiledoc, though.
There is a commented-out test for the type of nested lists that can appear in google docs HTML.

Pasting a list into content-kit can sometimes do nothing when the post to be inserted is a single list section. `PostEditor#insertPost` will incorrectly interpret that as a single markup section. This doesn't cause errors but it does prevent the list from being pasted. Pasting a list if it is part of a larger body (at least 1 other section) works correctly.