### PR TITLE
Return "moved" sections

### DIFF
--- a/src/js/editor/post.js
+++ b/src/js/editor/post.js
@@ -508,6 +508,7 @@ class PostEditor {
     const newSection = renderedSection.clone();
     this.removeSection(renderedSection);
     this.insertSectionBefore(collection, newSection, beforeSection);
+    return newSection;
   }
 
   /**
@@ -517,11 +518,13 @@ class PostEditor {
    */
   moveSectionUp(renderedSection) {
     const isFirst = !renderedSection.prev;
-    if (isFirst) { return; }
+    if (isFirst) {
+      return renderedSection;
+    }
 
     const collection = renderedSection.parent.sections;
     const beforeSection = renderedSection.prev;
-    this.moveSectionBefore(collection, renderedSection, beforeSection);
+    return this.moveSectionBefore(collection, renderedSection, beforeSection);
   }
 
   /**
@@ -531,11 +534,13 @@ class PostEditor {
    */
   moveSectionDown(renderedSection) {
     const isLast = !renderedSection.next;
-    if (isLast) { return; }
+    if (isLast) {
+      return renderedSection;
+    }
 
     const beforeSection = renderedSection.next.next;
     const collection = renderedSection.parent.sections;
-    this.moveSectionBefore(collection, renderedSection, beforeSection);
+    return this.moveSectionBefore(collection, renderedSection, beforeSection);
   }
 
   _replaceSection(section, newSections) {

--- a/tests/unit/editor/post-test.js
+++ b/tests/unit/editor/post-test.js
@@ -691,9 +691,10 @@ test('#moveSectionBefore moves the section as expected', (assert) => {
   const [headSection, tailSection] = post.sections.toArray();
   const collection = post.sections;
   postEditor = new PostEditor(mockEditor);
-  postEditor.moveSectionBefore(collection, tailSection, headSection);
+  let movedSection = postEditor.moveSectionBefore(collection, tailSection, headSection);
   postEditor.complete();
 
+  assert.equal(post.sections.head, movedSection, 'movedSection is returned');
   assert.equal(post.sections.head.text, '123', 'tail section is now head');
   assert.equal(post.sections.tail.text, 'abc', 'head section is now tail');
 });
@@ -741,10 +742,11 @@ test('#moveSectionUp moves it up', (assert) => {
   assert.equal(tailSection.name, 'listicle-card', 'listicle-card moved to last spot');
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.moveSectionUp(headSection);
+  let movedSection = postEditor.moveSectionUp(headSection);
   postEditor.complete();
 
   ([headSection, tailSection] = post.sections.toArray());
+  assert.equal(post.sections.head, movedSection, 'movedSection is returned');
   assert.equal(headSection.name, 'other-card', 'moveSectionUp is no-op when card is at top');
 });
 
@@ -767,10 +769,11 @@ test('moveSectionDown moves it down', (assert) => {
   assert.equal(tailSection.name, 'listicle-card', 'listicle-card moved to last spot');
 
   postEditor = new PostEditor(mockEditor);
-  postEditor.moveSectionDown(tailSection);
+  let movedSection = postEditor.moveSectionDown(tailSection);
   postEditor.complete();
 
   ([headSection, tailSection] = post.sections.toArray());
+  assert.equal(post.sections.tail, movedSection, 'movedSection is returned');
   assert.equal(tailSection.name, 'listicle-card',
                'moveSectionDown is no-op when card is at bottom');
  


### PR DESCRIPTION
To scroll to a moved card, the consumer may want access to the AT node that has been created by the move operation.

It strikes me working on this code that "move" is a poor name for a method that may actually destroy the node passed to it. We should improve the API around this.