### PR TITLE
Paste improvements

### DIFF
--- a/src/js/models/_section.js
+++ b/src/js/models/_section.js
@@ -34,11 +34,19 @@ export default class Section extends LinkedItem {
   }
 
   set tagName(val) {
-    this._tagName = normalizeTagName(val);
+    let normalizedTagName = normalizeTagName(val);
+    if (!this.isValidTagName(normalizedTagName)) {
+      throw new Error(`Cannot set section tagName to ${val}`);
+    }
+    this._tagName = normalizedTagName;
   }
 
   get tagName() {
     return this._tagName;
+  }
+
+  isValidTagName(/* normalizedTagName */) {
+    throw new Error('`isValidTagName` must be implemented by subclass');
   }
 
   get isBlank() {

--- a/src/js/models/list-item.js
+++ b/src/js/models/list-item.js
@@ -3,6 +3,7 @@ import { LIST_ITEM_TYPE } from './types';
 import {
   normalizeTagName
 } from 'content-kit-editor/utils/dom-utils';
+import { contains } from 'content-kit-editor/utils/array-utils';
 
 export const VALID_LIST_ITEM_TAGNAMES = [
   'li'
@@ -11,6 +12,10 @@ export const VALID_LIST_ITEM_TAGNAMES = [
 export default class ListItem extends Markerable {
   constructor(tagName, markers=[]) {
     super(LIST_ITEM_TYPE, tagName, markers);
+  }
+
+  isValidTagName(normalizedTagName) {
+    return contains(VALID_LIST_ITEM_TAGNAMES, normalizedTagName);
   }
 
   splitAtMarker(marker, offset=0) {

--- a/src/js/models/list-section.js
+++ b/src/js/models/list-section.js
@@ -1,5 +1,8 @@
 import LinkedList from '../utils/linked-list';
-import { forEach } from '../utils/array-utils';
+import {
+  forEach,
+  contains
+} from '../utils/array-utils';
 import { LIST_SECTION_TYPE } from './types';
 import Section from './_section';
 import {
@@ -25,6 +28,10 @@ export default class ListSection extends Section {
     this.sections = this.items;
 
     items.forEach(i => this.items.append(i));
+  }
+
+  isValidTagName(normalizedTagName) {
+    return contains(VALID_LIST_SECTION_TAGNAMES, normalizedTagName);
   }
 
   get isBlank() {

--- a/src/js/models/markup-section.js
+++ b/src/js/models/markup-section.js
@@ -1,5 +1,6 @@
 import Markerable from './_markerable';
 import { normalizeTagName } from '../utils/dom-utils';
+import { contains } from '../utils/array-utils';
 import { MARKUP_SECTION_TYPE } from './types';
 
 // valid values of `tagName` for a MarkupSection
@@ -20,16 +21,8 @@ const MarkupSection = class MarkupSection extends Markerable {
     super(MARKUP_SECTION_TYPE, tagName, markers);
   }
 
-  setTagName(newTagName) {
-    newTagName = normalizeTagName(newTagName);
-    if (VALID_MARKUP_SECTION_TAGNAMES.indexOf(newTagName) === -1) {
-      throw new Error(`Cannot change section tagName to "${newTagName}`);
-    }
-    this.tagName = newTagName;
-  }
-
-  resetTagName() {
-    this.tagName = DEFAULT_TAG_NAME;
+  isValidTagName(normalizedTagName) {
+    return contains(VALID_MARKUP_SECTION_TAGNAMES, normalizedTagName);
   }
 
   splitAtMarker(marker, offset=0) {

--- a/src/js/utils/cursor.js
+++ b/src/js/utils/cursor.js
@@ -105,6 +105,10 @@ const Cursor = class Cursor {
   }
 
   moveToPosition(position) {
+    if (position._inCard) {
+      // FIXME add the ability to position the cursor on/in a card
+      return;
+    }
     this.selectRange(new Range(position, position));
   }
 

--- a/tests/unit/models/markup-section-test.js
+++ b/tests/unit/models/markup-section-test.js
@@ -142,3 +142,9 @@ test('#markersFor clones a single marker with a tail offset', (assert) => {
   assert.equal(clones.length, 1);
   assert.equal(clones[0].value, ' ');
 });
+
+test('instantiating with invalid tagName throws', (assert) => {
+  assert.throws(() => {
+    builder.createMarkupSection('blah');
+  }, /Cannot set.*tagName.*blah/);
+});


### PR DESCRIPTION
This improves the ergonomics of pasting into content-kit. Pasting a single non-markup-section (like a card or a list section) now works properly (previously it would be ignored), and it replaces the empty section if the cursor is in an empty section.

Adds validations around tagNames that helps prevent corrupting mobiledocs by creating markupSections with, e.g., "li" tagNames.

It is still possible to confuse `postEdtior#insertPost` when inserting a post that contains a listSection when the cursor position is already in a listItem, but due to the tagName validations the mobiledoc does not end up with incorrect markup sections in it as a result.

 * handle pasting an empty post
 * Handle passing a non-markup section (list or card) to `insertPost`
 * make insertPost replace empty sections when pasting
 * Restrict tagNames to valid ones for markup section, list section, list item

fixes #196
fixes #190