### PR TITLE
Better error messages when parsing bad mobiledoc

### DIFF
--- a/src/js/parsers/mobiledoc.js
+++ b/src/js/parsers/mobiledoc.js
@@ -20,16 +20,20 @@ export default class MobiledocParser {
    * @return {Post}
    */
   parse({version, sections: sectionData}) {
-    const markerTypes = sectionData[0];
-    const sections    = sectionData[1];
+    try {
+      const markerTypes = sectionData[0];
+      const sections    = sectionData[1];
 
-    const post = this.builder.createPost();
+      const post = this.builder.createPost();
 
-    this.markups = [];
-    this.markerTypes = this.parseMarkerTypes(markerTypes);
-    this.parseSections(sections, post);
+      this.markups = [];
+      this.markerTypes = this.parseMarkerTypes(markerTypes);
+      this.parseSections(sections, post);
 
-    return post;
+      return post;
+    } catch (e) {
+      throw new Error(`Unable to parse mobiledoc: ${e.message}`);
+    }
   }
 
   parseMarkerTypes(markerTypes) {

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -228,3 +228,21 @@ test('#detectMarkupInRange matching bounds of marker', (assert) => {
   assert.ok(markup, 'selection has markup');
   assert.equal(markup.tagName, 'strong', 'detected markup is strong');
 });
+
+test('useful error message when given invalid mobiledoc', (assert) => {
+  let badMobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      ["incorrect"]
+    ]
+  };
+  assert.throws(() => {
+    new Editor({mobiledoc: badMobiledoc}); // jshint ignore:line
+  }, /unable to parse.*mobiledoc/i);
+
+  let verybadMobiledoc = "not mobiledoc";
+  assert.throws(() => {
+    new Editor({mobiledoc: verybadMobiledoc}); // jshint ignore:line
+  }, /unable to parse.*mobiledoc/i);
+});


### PR DESCRIPTION
Instantiating an editor with a corrupt/malformed mobiledoc currently throws cryptic errors like "cannot read property at 0".

fixes #177 