### PR TITLE
Parse nbsp into spaces, render nbsp where needed

### DIFF
--- a/src/js/parsers/dom.js
+++ b/src/js/parsers/dom.js
@@ -1,3 +1,4 @@
+import { NO_BREAK_SPACE } from '../renderers/editor-dom';
 import {
   MARKUP_SECTION_TYPE,
   LIST_SECTION_TYPE,
@@ -17,6 +18,13 @@ import { getAttributes, walkTextNodes } from '../utils/dom-utils';
 import Markup from 'content-kit-editor/models/markup';
 
 const GOOGLE_DOCS_CONTAINER_ID_REGEX = /^docs\-internal\-guid/;
+
+const NO_BREAK_SPACE_REGEX = new RegExp(NO_BREAK_SPACE, 'g');
+export function transformHTMLText(textContent) {
+  let text = textContent;
+  text = text.replace(NO_BREAK_SPACE_REGEX, ' ');
+  return text;
+}
 
 function isGoogleDocsContainer(element) {
   return !isTextNode(element) &&
@@ -154,7 +162,7 @@ export default class DOMParser {
     let previousMarker;
 
     walkTextNodes(element, (textNode) => {
-      const text = textNode.textContent;
+      const text = transformHTMLText(textNode.textContent);
       let markups = this.collectMarkups(textNode, element);
 
       let marker;

--- a/src/js/parsers/section.js
+++ b/src/js/parsers/section.js
@@ -35,6 +35,10 @@ import {
   contains
 } from 'content-kit-editor/utils/array-utils';
 
+import {
+  transformHTMLText
+} from '../parsers/dom';
+
 function isListSection(section) {
   return section.type === LIST_SECTION_TYPE;
 }
@@ -164,8 +168,7 @@ export default class SectionParser {
 
     // close a trailing text node if it exists
     if (state.text.length) {
-      let marker = this.builder.createMarker(state.text, state.markups);
-      state.section.markers.append(marker);
+      this._createMarker();
     }
 
     sections.push(state.section);
@@ -222,7 +225,8 @@ export default class SectionParser {
 
   _createMarker() {
     let { state } = this;
-    let marker = this.builder.createMarker(state.text, state.markups);
+    let text = transformHTMLText(state.text);
+    let marker = this.builder.createMarker(text, state.markups);
     state.section.markers.append(marker);
     state.text = '';
   }

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -8,6 +8,18 @@ const { test, module } = Helpers;
 
 let fixture, editor, editorElement;
 
+const mobileDocWithSection = {
+  version: MOBILEDOC_VERSION,
+  sections: [
+    [],
+    [
+      [1, "P", [
+        [[], 0, "one trick pony"]
+      ]]
+    ]
+  ]
+};
+
 const mobileDocWith2Sections = {
   version: MOBILEDOC_VERSION,
   sections: [
@@ -250,6 +262,21 @@ test('keystroke of printable character while text is selected deletes the text',
 
   assert.ok($(`#editor h2:contains(first Xd section)`).length,
             'updates the section');
+});
+
+test('selecting text bounded by space and typing replaces it', (assert) => {
+  editor = new Editor({mobiledoc: mobileDocWithSection});
+  editor.render(editorElement);
+
+  Helpers.dom.selectText('trick', editorElement);
+  Helpers.dom.insertText(editor, 'X');
+
+  assert.hasElement('#editor p:contains(one X pony)',
+                    'new text present');
+
+  Helpers.dom.insertText(editor, 'Y');
+  assert.hasElement('#editor p:contains(one XY pony)',
+                    'cursor positioned correctly');
 });
 
 test('selecting all text across sections and hitting enter deletes and moves cursor to empty section', (assert) => {

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -2,6 +2,7 @@ import PostNodeBuilder from 'content-kit-editor/models/post-node-builder';
 import Renderer from 'content-kit-editor/renderers/editor-dom';
 import RenderTree from 'content-kit-editor/models/render-tree';
 import Helpers from '../../test-helpers';
+import { NO_BREAK_SPACE } from 'content-kit-editor/renderers/editor-dom';
 const { module, test } = Helpers;
 
 const DATA_URL = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
@@ -584,6 +585,20 @@ test('renders markup section "pull-quote" as <div class="pull-quote"></div>', (a
 
   const expectedDOM = Helpers.dom.build(t => {
     return t('div', {"class": "pull-quote"}, [t.text('abc')]);
+  });
+
+  assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);
+});
+
+test('renders a bunch of spaces with nbsp', (assert) => {
+  const post = Helpers.postAbstract.build(({post, markupSection, marker}) => {
+    return post([markupSection('p', [marker('a b  c    d ')])]);
+  });
+  const renderTree = new RenderTree(post);
+  render(renderTree);
+
+  const expectedDOM = Helpers.dom.build(t => {
+    return t('p', {}, [t.text(`a b ${NO_BREAK_SPACE}c ${NO_BREAK_SPACE} ${NO_BREAK_SPACE}d${NO_BREAK_SPACE}`)]);
   });
 
   assert.equal(renderTree.rootElement.innerHTML, expectedDOM.outerHTML);


### PR DESCRIPTION
* Mobiledoc should, ideally, not contain any HTML entities. Instead these should be converted into their property plain text pair. This changes the parsing code to disallow nbsp chars, instead converting them into regular spaces.
* The Content-Kit renderer must display spaces correctly when there are multiple spaces in a row. This patch ensures that at least every other space character is displayed as an nbsp.

Fixes #195