### PR TITLE
WIP: Card cursors

### DIFF
--- a/demo/app/mobiledocs/simple-card.js
+++ b/demo/app/mobiledocs/simple-card.js
@@ -3,7 +3,9 @@ export var simpleCard = {
   sections: [
     [],
     [
-      [10, 'simple-card']
+      [1, 'p', [[[], 0, 'before']]],
+      [10, 'simple-card'],
+      [1, 'p', [[[], 0, 'after']]]
     ]
   ]
 };

--- a/src/css/application.less
+++ b/src/css/application.less
@@ -1,2 +1,3 @@
 @import 'editor';
+@import 'cards';
 @import 'tooltip';

--- a/src/css/cards.less
+++ b/src/css/cards.less
@@ -1,0 +1,3 @@
+.ck-card {
+  display: inline-block;
+}

--- a/src/js/editor/key-commands.js
+++ b/src/js/editor/key-commands.js
@@ -51,8 +51,8 @@ export const DEFAULT_KEY_COMMANDS = [{
     if (!editor.cursor.hasSelection()) {
       range.tail = new Position(range.head.section, range.head.section.length);
     }
-    editor.run(postEditor => postEditor.deleteRange(range));
-    editor.cursor.moveToPosition(range.head);
+    let nextPosition = editor.run(postEditor => postEditor.deleteRange(range));
+    editor.cursor.moveToPosition(nextPosition);
   }
 }, {
   modifier: MODIFIERS.META,

--- a/src/js/models/_markerable.js
+++ b/src/js/models/_markerable.js
@@ -7,6 +7,7 @@ import Section from './_section';
 export default class Markerable extends Section {
   constructor(type, tagName, markers=[]) {
     super(type);
+    this.isMarkerable = true;
     this.tagName = tagName;
     this.markers = new LinkedList({
       adoptItem: m => m.section = m.parent = this,

--- a/src/js/models/card.js
+++ b/src/js/models/card.js
@@ -15,6 +15,8 @@ export default class Card extends Section {
     this.name = name;
     this.payload = payload;
     this.setInitialMode(DEFAULT_INITIAL_MODE);
+    this.isCardSection = true;
+    this.length = 1;
   }
 
   get isBlank() {

--- a/src/js/models/render-tree.js
+++ b/src/js/models/render-tree.js
@@ -31,6 +31,31 @@ export default class RenderTree {
   removeElementRenderNode(element) {
     this._elements.remove(element);
   }
+  /**
+   * @param {DOMNode} element
+   * Walk up from the element until we find a renderNode element
+   */
+  findRenderNodeFromElement(element, conditionFn=()=>true) {
+    let renderNode;
+    while (element) {
+      renderNode = this.getElementRenderNode(element);
+      if (renderNode && conditionFn(renderNode)) {
+        return renderNode;
+      }
+
+      // continue loop
+      element = element.parentNode;
+
+      // stop if we are at the root element
+      if (element === this.rootElement) {
+        if (conditionFn(this.rootNode)) {
+          return this.rootNode;
+        } else {
+          return;
+        }
+      }
+    }
+  }
   buildRenderNode(postNode) {
     const renderNode = new RenderNode(postNode, this);
     postNode.renderNode = renderNode;

--- a/src/js/renderers/editor-dom.js
+++ b/src/js/renderers/editor-dom.js
@@ -81,10 +81,14 @@ function renderCursorPlaceholder() {
 }
 
 function renderCard() {
-  const element = document.createElement('div');
-  element.contentEditable = false;
-  addClassName(element, 'ck-card');
-  return element;
+  let wrapper = document.createElement('div');
+  let cardElement = document.createElement('div');
+  cardElement.contentEditable = false;
+  addClassName(cardElement, 'ck-card');
+  wrapper.appendChild(document.createTextNode('\u200c'));
+  wrapper.appendChild(cardElement);
+  wrapper.appendChild(document.createTextNode('\u200c'));
+  return { wrapper, cardElement };
 }
 
 function getNextMarkerElement(renderNode) {
@@ -249,19 +253,20 @@ class Visitor {
     const {editor, options} = this;
     const card = detect(this.cards, card => card.name === section.name);
 
-    renderNode.element = renderCard();
+    let { wrapper, cardElement } = renderCard();
+    renderNode.element = wrapper;
     attachRenderNodeElementToDOM(renderNode, originalElement);
 
     if (card) {
       const cardNode = new CardNode(
-        editor, card, section, renderNode.element, options);
+        editor, card, section, cardElement, options);
       renderNode.cardNode = cardNode;
       const initialMode = section._initialMode;
       cardNode[initialMode]();
     } else {
       const env = { name: section.name };
       this.unknownCardHandler(
-        renderNode.element, options, env, section.payload);
+        cardElement, options, env, section.payload);
     }
   }
 }

--- a/src/js/utils/cursor/range.js
+++ b/src/js/utils/cursor/range.js
@@ -1,9 +1,11 @@
 import Position from './position';
+import { DIRECTION } from '../key';
 
 export default class Range {
-  constructor(head, tail) {
+  constructor(head, tail, direction) {
     this.head = head;
     this.tail = tail;
+    this.direction = direction;
   }
 
   static create(headSection, headOffset, tailSection, tailOffset) {
@@ -34,6 +36,17 @@ export default class Range {
       Math.min(this.tail.offset, length) : length;
 
     return Range.create(section, headOffset, section, tailOffset);
+  }
+
+  moveFocusedPosition(direction) {
+    switch (this.direction) {
+      case DIRECTION.FORWARD:
+        return new Range(this.head, this.tail.move(direction), this.direction);
+      case DIRECTION.BACKWARD:
+        return new Range(this.head.move(direction), this.tail, this.direction);
+      default:
+        return new Range(this.head, this.tail, direction).moveFocusedPosition(direction);
+    }
   }
 
   // "legacy" APIs

--- a/src/js/utils/key.js
+++ b/src/js/utils/key.js
@@ -67,8 +67,26 @@ const Key = class Key {
     return this.keyCode === Keycodes.DELETE;
   }
 
+  isHorizontalArrow() {
+    return this.keyCode === Keycodes.LEFT ||
+      this.keyCode === Keycodes.RIGHT;
+  }
+
+  isLeftArrow() {
+    return this.keyCode === Keycodes.LEFT;
+  }
+
+  isRightArrow() {
+    return this.keyCode === Keycodes.RIGHT;
+  }
+
   get direction() {
-    return this.isForwardDelete() ? DIRECTION.FORWARD : DIRECTION.BACKWARD;
+    switch (true) {
+      case this.isDelete():
+        return this.isForwardDelete() ? DIRECTION.FORWARD : DIRECTION.BACKWARD;
+      case this.isHorizontalArrow():
+        return this.isRightArrow() ? DIRECTION.FORWARD : DIRECTION.BACKWARD;
+    }
   }
 
   isSpace() {

--- a/src/js/utils/selection-utils.js
+++ b/src/js/utils/selection-utils.js
@@ -1,3 +1,5 @@
+import { DIRECTION } from '../utils/key';
+
 function clearSelection() {
   // FIXME-IE ensure this works on IE 9. It works on IE10.
   window.getSelection().removeAllRanges();
@@ -15,24 +17,27 @@ function getSelectionContents() {
 
 function comparePosition(selection) {
   let { anchorNode, focusNode, anchorOffset, focusOffset } = selection;
-  let headNode, tailNode, headOffset, tailOffset;
+  let headNode, tailNode, headOffset, tailOffset, direction;
 
   const position = anchorNode.compareDocumentPosition(focusNode);
 
   if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
     headNode = anchorNode; tailNode = focusNode;
     headOffset = anchorOffset; tailOffset = focusOffset;
+    direction = DIRECTION.FORWARD;
   } else if (position & Node.DOCUMENT_POSITION_PRECEDING) {
     headNode = focusNode; tailNode = anchorNode;
     headOffset = focusOffset; tailOffset = anchorOffset;
+    direction = DIRECTION.BACKWARD;
   } else { // same node
     headNode = anchorNode;
     tailNode = focusNode;
     headOffset = Math.min(anchorOffset, focusOffset);
     tailOffset = Math.max(anchorOffset, focusOffset);
+    direction = null;
   }
 
-  return {headNode, headOffset, tailNode, tailOffset};
+  return {headNode, headOffset, tailNode, tailOffset, direction};
 }
 
 export {

--- a/tests/acceptance/basic-editor-test.js
+++ b/tests/acceptance/basic-editor-test.js
@@ -3,14 +3,23 @@ import Helpers from '../test-helpers';
 
 const { test, module } = Helpers;
 
-let fixture, editor, editorElement;
+const cards = [{
+  name: 'my-card',
+  display: {
+    setup() {},
+    teardown() {}
+  },
+  edit: {
+    setup() {},
+    teardown() {}
+  }
+}];
+
+let editor, editorElement;
 
 module('Acceptance: editor: basic', {
   beforeEach() {
-    fixture = document.getElementById('qunit-fixture');
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    fixture.appendChild(editorElement);
+    editorElement = $('#editor')[0];
   },
   afterEach() {
     if (editor) { editor.destroy(); }
@@ -105,4 +114,40 @@ test('typing in empty post correctly adds a section to it', (assert) => {
   assert.hasElement('#editor p:contains(X)');
   Helpers.dom.insertText(editor, 'Y');
   assert.hasElement('#editor p:contains(XY)', 'inserts text at correct spot');
+});
+
+test('typing when on the end of a card is blocked', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  let endingZWNJ = $('#editor')[0].firstChild.lastChild;
+  Helpers.dom.moveCursorTo(endingZWNJ, 0);
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasNoElement('#editor div:contains(X)');
+  Helpers.dom.moveCursorTo(endingZWNJ, 1);
+  Helpers.dom.insertText(editor, 'Y');
+  assert.hasNoElement('#editor div:contains(Y)');
+});
+
+test('typing when on the start of a card is blocked', (assert) => {
+  const mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  let startingZWNJ = $('#editor')[0].firstChild.firstChild;
+  Helpers.dom.moveCursorTo(startingZWNJ, 0);
+  Helpers.dom.insertText(editor, 'X');
+  assert.hasNoElement('#editor div:contains(X)');
+  Helpers.dom.moveCursorTo(startingZWNJ, 1);
+  Helpers.dom.insertText(editor, 'Y');
+  assert.hasNoElement('#editor div:contains(Y)');
 });

--- a/tests/acceptance/cursor-movement-test.js
+++ b/tests/acceptance/cursor-movement-test.js
@@ -1,0 +1,265 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+import { MODIFIERS } from 'content-kit-editor/utils/key';
+
+const { test, module } = Helpers;
+
+const cards = [{
+  name: 'my-card',
+  display: {
+    setup() {},
+    teardown() {}
+  },
+  edit: {
+    setup() {},
+    teardown() {}
+  }
+}];
+
+let editor, editorElement;
+
+module('Acceptance: Cursor Movement', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('left arrow when at the end of a card moves the cursor across the card', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // Before zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.lastChild, 0);
+  Helpers.dom.triggerLeftArrowKey(editor);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+
+  // After zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.lastChild, 1);
+  Helpers.dom.triggerLeftArrowKey(editor);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+
+  // On wrapper
+  Helpers.dom.moveCursorTo(editorElement.firstChild, 2);
+  Helpers.dom.triggerLeftArrowKey(editor);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+});
+
+test('left arrow when at the start of a card moves the cursor to the previous section', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      markupSection('p'),
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // Before zwnj
+  let sectionElement = editor.post.sections.tail.renderNode.element;
+  Helpers.dom.moveCursorTo(sectionElement.firstChild, 0);
+  Helpers.dom.triggerLeftArrowKey(editor);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+
+  // After zwnj
+  sectionElement = editor.post.sections.tail.renderNode.element;
+  Helpers.dom.moveCursorTo(sectionElement.firstChild, 1);
+  Helpers.dom.triggerLeftArrowKey(editor);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+});
+
+test('right arrow moves the cursor across the card', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // Before zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 0);
+  Helpers.dom.triggerRightArrowKey(editor);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 1,
+               'Cursor is positioned at offset 1');
+
+  // After zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 1);
+  Helpers.dom.triggerRightArrowKey(editor);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 1,
+               'Cursor is positioned at offset 1');
+});
+
+test('right arrow at end of card moves cursor to next section', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      cardSection('my-card'),
+      markupSection('p')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // Before zwnj
+  let sectionElement = editor.post.sections.head.renderNode.element;
+  Helpers.dom.moveCursorTo(sectionElement.lastChild, 0);
+  Helpers.dom.triggerRightArrowKey(editor);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.tail,
+            'Cursor is positioned on tail section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+
+  // After zwnj
+  sectionElement = editor.post.sections.head.renderNode.element;
+  Helpers.dom.moveCursorTo(sectionElement.lastChild, 1);
+  Helpers.dom.triggerRightArrowKey(editor);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.tail,
+            'Cursor is positioned on tail section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+});
+
+module('Acceptance: Cursor Movement w/ shift', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('left arrow when at the end of a card moves the cursor across the card', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // Before zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.lastChild, 0);
+  Helpers.dom.triggerLeftArrowKey(editor, MODIFIERS.SHIFT);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'selection head is positioned on first section');
+  assert.ok(offsets.tail.section === editor.post.sections.head,
+            'selection tail is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'selection head is positioned at offset 0');
+  assert.equal(offsets.tail.offset, 1,
+               'selection tail is positioned at offset 1');
+
+  // After zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.lastChild, 1);
+  Helpers.dom.triggerLeftArrowKey(editor, MODIFIERS.SHIFT);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'selection head is positioned on first section');
+  assert.ok(offsets.tail.section === editor.post.sections.head,
+            'selection tail is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'selection head is positioned at offset 0');
+  assert.equal(offsets.tail.offset, 1,
+               'selection tail is positioned at offset 1');
+
+  // On wrapper
+  Helpers.dom.moveCursorTo(editorElement.firstChild, 2);
+  Helpers.dom.triggerLeftArrowKey(editor, MODIFIERS.SHIFT);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'selection head is positioned on first section');
+  assert.ok(offsets.tail.section === editor.post.sections.head,
+            'selection tail is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'selection head is positioned at offset 0');
+  assert.equal(offsets.tail.offset, 1,
+               'selection tail is positioned at offset 1');
+});
+
+test('right arrow moves the cursor across the card', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, cardSection}) => {
+    return post([
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // Before zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 0);
+  Helpers.dom.triggerRightArrowKey(editor, MODIFIERS.SHIFT);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'selection head is positioned on first section');
+  assert.ok(offsets.tail.section === editor.post.sections.head,
+            'selection tail is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'selection head is positioned at offset 0');
+  assert.equal(offsets.tail.offset, 1,
+               'selection tail is positioned at offset 1');
+
+  // After zwnj
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 1);
+  Helpers.dom.triggerRightArrowKey(editor, MODIFIERS.SHIFT);
+  offsets = editor.cursor.offsets;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'selection head is positioned on first section');
+  assert.ok(offsets.tail.section === editor.post.sections.head,
+            'selection tail is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'selection head is positioned at offset 0');
+  assert.equal(offsets.tail.offset, 1,
+               'selection tail is positioned at offset 1');
+});

--- a/tests/acceptance/cursor-position-test.js
+++ b/tests/acceptance/cursor-position-test.js
@@ -1,0 +1,214 @@
+import { Editor } from 'content-kit-editor';
+import Helpers from '../test-helpers';
+
+const { test, module } = Helpers;
+
+const cards = [{
+  name: 'my-card',
+  display: {
+    setup() {},
+    teardown() {}
+  },
+  edit: {
+    setup() {},
+    teardown() {}
+  }
+}];
+
+let editor, editorElement;
+
+module('Acceptance: Cursor Position', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+test('cursor in a markup section reports its position correctly', assert => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
+    return post([
+      markupSection('p', [
+        marker('abc')
+      ])
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 1);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 1,
+               'Cursor is positioned at offset 1');
+});
+
+test('cursor blank section reports its position correctly', (assert) => {
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection}) => {
+    return post([
+      markupSection('p')
+    ]);
+  });
+  editor = new Editor({mobiledoc});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 0);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+});
+
+test('cursor moved left from section after card is reported as on the card with offset 1', (assert) => {
+  // Cannot actually move a cursor, so just emulate what things looks like after
+  // the arrow key is pressed
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      cardSection('my-card'),
+      markupSection('p')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.firstChild.lastChild, 1);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 1,
+               'Cursor is positioned at offset 1');
+});
+
+test('cursor moved up from end of section after card is reported as on the card with offset 1', (assert) => {
+  // Cannot actually move a cursor, so just emulate what things looks like after
+  // the arrow key is pressed
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      cardSection('my-card'),
+      markupSection('p')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.firstChild.lastChild, 0);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.head,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 1,
+               'Cursor is positioned at offset 1');
+});
+
+test('cursor moved right from end of section before card is reported as on the card with offset 0', (assert) => {
+  // Cannot actually move a cursor, so just emulate what things looks like after
+  // the arrow key is pressed
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      markupSection('p'),
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.lastChild.firstChild, 0);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.tail,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+});
+
+test('cursor moved right from end of section before card is reported as on the card with offset 0', (assert) => {
+  // Cannot actually move a cursor, so just emulate what things looks like after
+  // the arrow key is pressed
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      markupSection('p'),
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  Helpers.dom.moveCursorTo(editorElement.lastChild.firstChild, 1);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.head.section === editor.post.sections.tail,
+            'Cursor is positioned on first section');
+  assert.equal(offsets.head.offset, 0,
+               'Cursor is positioned at offset 0');
+});
+
+test('cursor focused on card wrapper with 2 offset', (assert) => {
+  // Cannot actually move a cursor, so just emulate what things looks like after
+  // the arrow key is pressed
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      markupSection('p'),
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // We need to create a selection starting from the markup section's node
+  // in order for the tail to end up focused on a div instead of a text node
+  // This only happens in Firefox
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 0, 
+                           editorElement.lastChild, 2);
+
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.tail.section === editor.post.sections.tail,
+            'Cursor tail is positioned on card section');
+  assert.equal(offsets.tail.offset, 1,
+               'Cursor tail is positioned at offset 1');
+});
+
+// This can happen when using arrow+shift keys to select left across a card
+test('cursor focused on card wrapper with 0 offset', (assert) => {
+  // Cannot actually move a cursor, so just emulate what things looks like after
+  // the arrow key is pressed
+  let mobiledoc = Helpers.mobiledoc.build(({post, markupSection, cardSection}) => {
+    return post([
+      markupSection('p'),
+      cardSection('my-card')
+    ]);
+  });
+  editor = new Editor({mobiledoc, cards});
+  editor.render(editorElement);
+
+  // We need to create a selection starting from the markup section's node
+  // in order for the tail to end up focused on a div instead of a text node
+  Helpers.dom.moveCursorTo(editorElement.firstChild.firstChild, 0,
+                           editorElement.lastChild, 0);
+  let { offsets } = editor.cursor;
+
+  assert.ok(offsets.tail.section === editor.post.sections.tail,
+            'Cursor tail is positioned on card section');
+  assert.equal(offsets.tail.offset, 0,
+               'Cursor tail is positioned at offset 0');
+});
+
+     
+     
+//inside card wrapper div and before starting zwnj reports its position correctly');
+
+/*
+// These could maybe be done better with arrow keys to get in the cases we want
+// to reproduce. Jumping straight to the DOM nodes in not very acceptancy and may
+// obscure real browser behavior.
+test('cursor inside card wrapper div and after starting zwnj reports its position correctly');
+test('cursor inside card wrapper div and before ending zwnj reports its position correctly');
+test('cursor inside card wrapper div and after ending zwnj reports its position correctly');
+*/

--- a/tests/acceptance/editor-key-commands-test.js
+++ b/tests/acceptance/editor-key-commands-test.js
@@ -8,9 +8,7 @@ let editor, editorElement;
 
 module('Acceptance: Editor: Key Commands', {
   beforeEach() {
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    $('#qunit-fixture').append(editorElement);
+    editorElement = $('#editor')[0];
   },
   afterEach() {
     if (editor) {

--- a/tests/acceptance/editor-list-test.js
+++ b/tests/acceptance/editor-list-test.js
@@ -28,9 +28,7 @@ function createEditorWithListMobiledoc() {
 
 module('Acceptance: Editor: Lists', {
   beforeEach() {
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    $('#qunit-fixture').append(editorElement);
+    editorElement = $('#editor')[0];
   },
   afterEach() {
     if (editor) { editor.destroy(); }

--- a/tests/acceptance/editor-post-editor-test.js
+++ b/tests/acceptance/editor-post-editor-test.js
@@ -7,8 +7,7 @@ let editor, editorElement;
 
 module('Acceptance: Editor - PostEditor', {
   beforeEach() {
-    editorElement = $('<div id="editor"></div>')[0];
-    $('#qunit-fixture').append($(editorElement));
+    editorElement = $('#editor')[0];
   },
   afterEach() {
     if (editor) { editor.destroy(); }

--- a/tests/acceptance/editor-sections-test.js
+++ b/tests/acceptance/editor-sections-test.js
@@ -5,7 +5,7 @@ import { NO_BREAK_SPACE } from 'content-kit-editor/renderers/editor-dom';
 
 const { test, module } = Helpers;
 
-let fixture, editor, editorElement;
+let editor, editorElement;
 const mobileDocWith1Section = {
   version: MOBILEDOC_VERSION,
   sections: [
@@ -88,9 +88,7 @@ const mobileDocWithNoCharacter = {
 
 module('Acceptance: Editor sections', {
   beforeEach() {
-    fixture = $('#qunit-fixture');
-    editorElement = $('<div id="editor"></div>')[0];
-    fixture.append(editorElement);
+    editorElement = $('#editor')[0];
   },
 
   afterEach() {

--- a/tests/acceptance/editor-selections-test.js
+++ b/tests/acceptance/editor-selections-test.js
@@ -4,7 +4,7 @@ import { MOBILEDOC_VERSION } from 'content-kit-editor/renderers/mobiledoc';
 
 const { test, module } = Helpers;
 
-let fixture, editor, editorElement;
+let editor, editorElement;
 
 const mobileDocWithSection = {
   version: MOBILEDOC_VERSION,
@@ -35,10 +35,7 @@ const mobileDocWith2Sections = {
 
 module('Acceptance: Editor Selections', {
   beforeEach() {
-    fixture = document.getElementById('qunit-fixture');
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    fixture.appendChild(editorElement);
+    editorElement = $('#editor')[0];
   },
 
   afterEach() {
@@ -326,7 +323,6 @@ test('selecting text across markup and list sections', (assert) => {
   editor.render(editorElement);
 
   Helpers.dom.selectText('bc', editorElement, '12', editorElement);
-  Helpers.dom.triggerEvent(document, 'mouseup');
 
   Helpers.dom.triggerDelete(editor);
 

--- a/tests/acceptance/editor-text-expansions-test.js
+++ b/tests/acceptance/editor-text-expansions-test.js
@@ -15,9 +15,7 @@ function insertText(text, cursorNode) {
 
 module('Acceptance: Editor: Text Expansions', {
   beforeEach() {
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    $('#qunit-fixture').append(editorElement);
+    editorElement = $('#editor')[0];
   },
   afterEach() {
     if (editor) { editor.destroy(); }

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -23,6 +23,11 @@ const test = (msg, callback) => {
   qunitTest(msg, callback);
 };
 
+QUnit.testStart(() => {
+  // The fixture is cleared between tests, clearing this
+  $('<div id="editor"></div>').appendTo('#qunit-fixture');
+});
+
 export default {
   dom: DOMHelpers,
   mobiledoc: MobiledocHelpers,

--- a/tests/unit/editor/card-lifecycle-test.js
+++ b/tests/unit/editor/card-lifecycle-test.js
@@ -7,9 +7,7 @@ const { module, test } = Helpers;
 
 module('Unit: Editor: Card Lifecycle', {
   beforeEach() {
-    editorElement = document.createElement('div');
-    editorElement.setAttribute('id', 'editor');
-    $('#qunit-fixture').append(editorElement);
+    editorElement = $('#editor')[0];
   },
   afterEach() {
     if (editor) {

--- a/tests/unit/editor/editor-events-test.js
+++ b/tests/unit/editor/editor-events-test.js
@@ -12,7 +12,7 @@ const mobiledoc = Helpers.mobiledoc.build(({post, markupSection, marker}) => {
 
 module('Unit: Editor: events and lifecycle callbacks', {
   beforeEach() {
-    editorElement = $('<div id="editor"></div>').appendTo('#qunit-fixture')[0];
+    editorElement = $('#editor')[0];
     editor = new Editor({mobiledoc});
     editor.render(editorElement);
   },

--- a/tests/unit/editor/editor-test.js
+++ b/tests/unit/editor/editor-test.js
@@ -7,15 +7,11 @@ import Helpers from '../../test-helpers';
 
 const { module, test } = Helpers;
 
-let fixture, editorElement, editor;
+let editorElement, editor;
 
 module('Unit: Editor', {
   beforeEach() {
-    fixture = document.getElementById('qunit-fixture');
-    editorElement = document.createElement('div');
-    editorElement.id = 'editor1';
-    editorElement.className = 'editor';
-    fixture.appendChild(editorElement);
+    editorElement = $('#editor')[0];
   },
 
   afterEach() {

--- a/tests/unit/parsers/dom-test.js
+++ b/tests/unit/parsers/dom-test.js
@@ -6,11 +6,12 @@ import { NO_BREAK_SPACE } from 'content-kit-editor/renderers/editor-dom';
 
 const {module, test} = Helpers;
 
-let builder, parser, editor;
+let editorElement, builder, parser, editor;
 let buildDOM = Helpers.dom.fromHTML;
 
 module('Unit: Parser: DOMParser', {
   beforeEach() {
+    editorElement = $('#editor')[0];
     builder = new PostNodeBuilder();
     parser = new DOMParser(builder);
   },
@@ -67,8 +68,6 @@ test('editor#reparse catches changes to section', (assert) => {
     ])
   );
   editor = new Editor({mobiledoc});
-  const editorElement = $('<div id="editor"></div>')[0];
-  $('#qunit-fixture').append(editorElement);
   editor.render(editorElement);
 
   assert.hasElement('#editor p:contains(the marker)', 'precond - rendered correctly');
@@ -92,8 +91,6 @@ test('editor#reparse parses spaces and breaking spaces', (assert) => {
     ])
   );
   editor = new Editor({mobiledoc});
-  const editorElement = $('<div id="editor"></div>')[0];
-  $('#qunit-fixture').append(editorElement);
   editor.render(editorElement);
 
   assert.hasElement('#editor p:contains(the marker)', 'precond - rendered correctly');
@@ -119,8 +116,6 @@ test('editor#reparse catches changes to list section', (assert) => {
     ])
   );
   editor = new Editor({mobiledoc});
-  const editorElement = $('<div id="editor"></div>')[0];
-  $('#qunit-fixture').append(editorElement);
   editor.render(editorElement);
 
   assert.hasElement('#editor li:contains(list item)', 'precond - rendered correctly');

--- a/tests/unit/renderers/editor-dom-test.js
+++ b/tests/unit/renderers/editor-dom-test.js
@@ -5,6 +5,8 @@ import Helpers from '../../test-helpers';
 import { NO_BREAK_SPACE } from 'content-kit-editor/renderers/editor-dom';
 const { module, test } = Helpers;
 
+const ZWNJ = '\u200c';
+
 const DATA_URL = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
 let builder;
 
@@ -186,32 +188,12 @@ test('renders a card section', (assert) => {
   const renderTree = new RenderTree(post);
   render(renderTree, [card]);
 
-  assert.equal(renderTree.rootElement.firstChild.innerHTML, 'I am a card',
+  // Use a wrapper an innerHTML to satisfy different browser attribute
+  // ordering quirks
+  let expectedWrapper = $(`<div>${ZWNJ}<div contenteditable="false" class="ck-card">I am a card</div>${ZWNJ}</div>`);
+  assert.equal(renderTree.rootElement.firstChild.innerHTML,
+               expectedWrapper.html(),
               'card is rendered');
-});
-
-test('renders a card section into a non-contenteditable element', (assert) => {
-  assert.expect(2);
-
-  let post = builder.createPost();
-  let cardSection = builder.createCardSection('my-card');
-  let card = {
-    name: 'my-card',
-    display: {
-      setup(element) {
-        element.setAttribute('id', 'my-card-div');
-      }
-    }
-  };
-  post.sections.append(cardSection);
-
-  const renderTree = new RenderTree(post);
-  render(renderTree, [card]);
-
-  let element = renderTree.rootElement.firstChild;
-  assert.equal(element.getAttribute('id'), 'my-card-div',
-               'precond - correct element selected');
-  assert.equal(element.contentEditable, 'false', 'is not contenteditable');
 });
 
 /*
@@ -547,7 +529,7 @@ test('includes card sections in renderTree element map', (assert) => {
 
   $('#qunit-fixture')[0].appendChild(renderTree.rootElement);
 
-  const element = $('#simple-card')[0];
+  const element = $('#simple-card').parent()[0];
   assert.ok(!!element, 'precond - simple card is rendered');
   assert.ok(!!renderTree.getElementRenderNode(element),
             'has render node for card element');


### PR DESCRIPTION
Introduces cursor positions at the head and tail of a card.

![](http://g.recordit.co/YrUI3DBXOM.gif)

Super important. TODO:

* [x] Ensure inner events are still ignored (we disabled this at the start of work)
* [x] Make character entry work at head and tail of card (should do nothing)
* [x] Make newline entry work at head and tail of card
* [x] Make delete/backspace press work at head and tail of card
* [x] Fix selections through head and tail

Fixes #182